### PR TITLE
Rename slack channel

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,7 +22,7 @@
 Если вы хотите связаться с нами, можно использовать несколько способов:
 
 * [Google группа](https://groups.google.com/forum/#!forum/easyeplanner)
-* Канал в [Slack](https://slack.com/) - easyeplaner.slack.com
+* Канал в [Slack](https://slack.com/) - easyeplanner.slack.com
 
 ### Нормы поведения(Code of conduct)
 Мы [используем](https://github.com/savushkin-r-d/EasyEPLANner/blob/master/docs/CODE_OF_CONDUCT.md) стандартные нормы поведения (общения), которые предоставляет сервис GitHub

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,4 +45,4 @@ PB (pull request) не обязательно должен представля�
 
 Помимо issue для связи с нами можно использовать:
 + [Google groups](https://groups.google.com/forum/#!forum/easyeplanner)
-+ Slack - easyeplaner.slack.com
++ Slack - easyeplanner.slack.com


### PR DESCRIPTION
Fixes #20.

**Решение**
Переименован канал во всех файлах документации, в которых содержалось старое название.