### PR TITLE
Fixed cloning functions leading to wrong string in actions

### DIFF
--- a/src/TechObject.cs
+++ b/src/TechObject.cs
@@ -3980,18 +3980,20 @@ namespace TechObject
             return clone;
         }
 
-        virtual public void ModifyDevNames(int newTechObjectN, int oldTechObjectN,
-            string techObjectName)
+        virtual public void ModifyDevNames(int newTechObjectN, 
+            int oldTechObjectN, string techObjectName)
         {
             List<int> tmpIndex = new List<int>();
             foreach (int index in deviceIndex)
             {
                 tmpIndex.Add(index);
             }
-            Device.DeviceManager deviceManager = Device.DeviceManager.GetInstance();
+            
+            Device.DeviceManager deviceManager = Device.DeviceManager
+                .GetInstance();
             foreach (int index in deviceIndex)
             {
-                string newDevName = "";
+                var newDevName = string.Empty;
                 Device.IODevice device = deviceManager.GetDeviceByIndex(index);
                 int objNum = device.ObjectNumber;
                 string objName = device.ObjectName;
@@ -4005,26 +4007,29 @@ namespace TechObject
                         if (objNum == newTechObjectN && oldTechObjectN != -1)
                         {
                             newDevName = objName + oldTechObjectN +
-                                device.DeviceType.ToString() + device.DeviceNumber;
+                                device.DeviceType.ToString() + device.
+                                DeviceNumber;
                         }
                         if (oldTechObjectN == -1 ||
                             oldTechObjectN == objNum)
                         {
                             //COAG1V1 --> COAG2V1
                             newDevName = objName + newTechObjectN +
-                                device.DeviceType.ToString() + device.DeviceNumber;
+                                device.DeviceType.ToString() + device.
+                                DeviceNumber;
                         }
                     }
                 }
 
-                if (newDevName != "")
+                if (newDevName != string.Empty)
                 {
+                    int indexOfDeletingElement = tmpIndex.IndexOf(index);
                     tmpIndex.Remove(index);
-                    int tmpDevInd =
-                        Device.DeviceManager.GetInstance().GetDeviceListNumber(newDevName);
+                    int tmpDevInd = Device.DeviceManager.GetInstance()
+                        .GetDeviceListNumber(newDevName);
                     if (tmpDevInd >= 0)
                     {
-                        tmpIndex.Add(tmpDevInd);
+                        tmpIndex.Insert(indexOfDeletingElement, tmpDevInd);
                     }
                 }
             }
@@ -4040,10 +4045,12 @@ namespace TechObject
             {
                 tmpIndex.Add(index);
             }
-            Device.DeviceManager deviceManager = Device.DeviceManager.GetInstance();
+
+            Device.DeviceManager deviceManager = Device.DeviceManager
+                .GetInstance();
             foreach (int index in deviceIndex)
             {
-                string newDevName = "";
+                string newDevName = string.Empty;
                 Device.IODevice device = deviceManager.GetDeviceByIndex(index);
                 int objNum = newTechObjectNumber;
                 string objName = device.ObjectName;
@@ -4055,14 +4062,15 @@ namespace TechObject
                         device.DeviceType.ToString() + device.DeviceNumber;
                 }
 
-                if (newDevName != "")
+                if (newDevName != string.Empty)
                 {
+                    int indexOfDeletingElement = tmpIndex.IndexOf(index);
                     tmpIndex.Remove(index);
-                    int tmpDevInd =
-                        Device.DeviceManager.GetInstance().GetDeviceListNumber(newDevName);
+                    int tmpDevInd = Device.DeviceManager.GetInstance()
+                        .GetDeviceListNumber(newDevName);
                     if (tmpDevInd >= 0)
                     {
-                        tmpIndex.Add(tmpDevInd);
+                        tmpIndex.Insert(indexOfDeletingElement, tmpDevInd);
                     }
                 }
             }

--- a/src/TechObject.cs
+++ b/src/TechObject.cs
@@ -4015,8 +4015,8 @@ namespace TechObject
                         {
                             //COAG1V1 --> COAG2V1
                             newDevName = objName + newTechObjectN +
-                                device.DeviceType.ToString() + device.
-                                DeviceNumber;
+                                device.DeviceType.ToString() + device
+                                .DeviceNumber;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #37 

**Решение**
Исправление функций модификации имен (LINE1 поменять на LINE2)

Она вставляла элементы в список в конец, а надо было в место, откуда был удален элемент