### PR TITLE
Removed automatic set P_ERR parameter in TE

### DIFF
--- a/src/Device.cs
+++ b/src/Device.cs
@@ -2658,7 +2658,7 @@ namespace Device
             {
                 case "TE":
                     parameters.Add("P_C0", null);
-                    parameters.Add("P_ERR", -1000);
+                    parameters.Add("P_ERR", null);
                     break;
 
                 case "TE_IOLINK":


### PR DESCRIPTION
Fixes #74.

**Решение**
Изначально параметр P_ERR задавался системой как "-1000", но это ошибочно, так как он может иметь значение и "1000", а т.к система задавала его сама, он не был пустым. Поэтому,  автоматическая установка системой заменена ручной установкой с выводом ошибки, если параметр не задан.