### PR TITLE
Added new text comments into saving main.restrictions.lua

### DIFF
--- a/src/TechObject/ModesManager.cs
+++ b/src/TechObject/ModesManager.cs
@@ -84,7 +84,8 @@ namespace TechObject
             foreach (Mode mode in modes)
             {
                 string tmp = "";
-                string comment = "\t\t--Операция №" + i.ToString();
+                string comment = $"\t\t--Операция №{i.ToString()} " +
+                    $"({mode.Name})";
 
                 tmp += mode.SaveRestrictionAsLua(prefix + "\t\t");
                 if (tmp != "")

--- a/src/TechObject/ModesManager.cs
+++ b/src/TechObject/ModesManager.cs
@@ -84,8 +84,7 @@ namespace TechObject
             foreach (Mode mode in modes)
             {
                 string tmp = "";
-                string comment = $"\t\t--Операция №{i.ToString()} " +
-                    $"({mode.Name})";
+                string comment = $"\t\t--{mode.Name}";
 
                 tmp += mode.SaveRestrictionAsLua(prefix + "\t\t");
                 if (tmp != "")

--- a/src/TechObject/TechObject.cs
+++ b/src/TechObject/TechObject.cs
@@ -185,7 +185,7 @@ namespace TechObject
         {
             string res = "";
             string tmp = "";
-            string comment = $"\t\t--{this.Name}{getN(this)}";
+            string comment = $"\t\t--{this.Name} {this.TechNumber}";
 
             tmp += modes.SaveRestrictionAsLua(prefix);
             if (tmp != "")

--- a/src/TechObject/TechObject.cs
+++ b/src/TechObject/TechObject.cs
@@ -185,7 +185,7 @@ namespace TechObject
         {
             string res = "";
             string tmp = "";
-            string comment = $"\t\t--Объект №{getN(this)} ({this.Name})";
+            string comment = $"\t\t--{this.Name}{getN(this)}";
 
             tmp += modes.SaveRestrictionAsLua(prefix);
             if (tmp != "")

--- a/src/TechObject/TechObject.cs
+++ b/src/TechObject/TechObject.cs
@@ -185,7 +185,7 @@ namespace TechObject
         {
             string res = "";
             string tmp = "";
-            string comment = "\t\t--Объект №" + getN(this);
+            string comment = $"\t\t--Объект №{getN(this)} ({this.Name})";
 
             tmp += modes.SaveRestrictionAsLua(prefix);
             if (tmp != "")


### PR DESCRIPTION
Fixes #119 

**Решение**
Номера объектов и операций можно взять из индекса. В этом комментарии нет особо необходимости. Вместо них будет указываться названия объекта (вместо комментария с номером объекта) и название операции (вместо комментария с номером операции).