### PR TITLE
Удалено сохранение устаревшего описания технологических объектов

### DIFF
--- a/src/Lua/sys.lua
+++ b/src/Lua/sys.lua
@@ -59,9 +59,6 @@ init = function()
                     proc_operation( value, mode, state_n )
 
                 end
-            else
-                --Совместимость со старой версией.
-                proc_operation( value, mode, 0 )
             end
         end
     end

--- a/src/TechObject/Mode.cs
+++ b/src/TechObject/Mode.cs
@@ -153,7 +153,6 @@ namespace TechObject
                 "\',\n";
 
             res += baseOperation.SaveAsLuaTable(prefix);
-            string tmp = "";
             int i = 1;
             string tmp_2 = "";
 

--- a/src/TechObject/Mode.cs
+++ b/src/TechObject/Mode.cs
@@ -155,6 +155,7 @@ namespace TechObject
             res += baseOperation.SaveAsLuaTable(prefix);
             int i = 1;
             string tmp = "";
+            string tmp_2 = "";
 
             for (int j = 0; j < stepsMngr.Count; j++)
             {

--- a/src/TechObject/Mode.cs
+++ b/src/TechObject/Mode.cs
@@ -153,8 +153,9 @@ namespace TechObject
                 "\',\n";
 
             res += baseOperation.SaveAsLuaTable(prefix);
+
             int i = 1;
-            string tmp = "";
+            string tmp;
             string tmp_2 = "";
 
             for (int j = 0; j < stepsMngr.Count; j++)

--- a/src/TechObject/Mode.cs
+++ b/src/TechObject/Mode.cs
@@ -154,7 +154,7 @@ namespace TechObject
 
             res += baseOperation.SaveAsLuaTable(prefix);
             int i = 1;
-            string tmp_2 = "";
+            string tmp = "";
 
             for (int j = 0; j < stepsMngr.Count; j++)
             {

--- a/src/TechObject/Mode.cs
+++ b/src/TechObject/Mode.cs
@@ -153,23 +153,7 @@ namespace TechObject
                 "\',\n";
 
             res += baseOperation.SaveAsLuaTable(prefix);
-
             string tmp = "";
-            //Совместимость с предыдущей версией (до введения состояния для
-            //операции).
-            if (stepsMngr.Count > 0)
-            {
-                tmp = stepsMngr[0].SaveAsLuaTable(prefix);
-                if (tmp != "")
-                {
-                    res += prefix + "--Совместимость с предыдущей версией" +
-                        " (до введения состояния для операции).\n";
-                    res += tmp;
-                    res += prefix + "--Совместимость с предыдущей версией.\n";
-                    res += "\n";
-                }
-            }
-
             int i = 1;
             string tmp_2 = "";
 


### PR DESCRIPTION
Fixes #174. 
Удалено сохранение устаревшего описания технологических объектов. В текущей версии в файл описания `main.objects.lua` не сохраняются фрагменты для совместимости с реализованными проектами без состояний операций. 
