### PR TITLE
Refactored main.cs

### DIFF
--- a/src/EasyEPlanner.csproj
+++ b/src/EasyEPlanner.csproj
@@ -204,18 +204,28 @@
       <DependentUpon>LogFrm.cs</DependentUpon>
     </Compile>
     <Compile Include="Logs\Logs.cs" />
+    <Compile Include="Main\AboutProgrammAction.cs" />
+    <Compile Include="Main\AddInModule.cs" />
+    <Compile Include="Main\BindingSynchronizationAction.cs" />
+    <Compile Include="Main\ExportTechDevsToExcelAction.cs" />
+    <Compile Include="Main\LoadDescriptionAction.cs" />
+    <Compile Include="Main\SaveAsXMLAction.cs" />
+    <Compile Include="Main\SaveDescriptionAction.cs" />
+    <Compile Include="Main\ShowDevicesAction.cs" />
+    <Compile Include="Main\ShowOperationsAction.cs" />
+    <Compile Include="Main\ShowTechObjectsAction.cs" />
     <Compile Include="ModeFrm.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="ModeFrm.Designer.cs">
       <DependentUpon>ModeFrm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ModulesBindingUpdater.cs" />
     <Compile Include="PInvokeUtil.cs" />
     <Compile Include="FileSavers\PrgLuaSaver.cs" />
     <Compile Include="ProjectConfiguration.cs" />
     <Compile Include="FileSavers\ProjectDescriptionSaver.cs" />
     <Compile Include="ProjectManager.cs" />
-    <Compile Include="main.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Main/AboutProgrammAction.cs
+++ b/src/Main/AboutProgrammAction.cs
@@ -1,0 +1,48 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие "О программе"
+    /// </summary>
+    public class AboutProgramm : IEplAction
+    {
+        ~AboutProgramm() { }
+
+        public bool Execute(ActionCallingContext ctx)
+        {
+            string message = $"Версия надстройки - {GetVersion()}\n" +
+               "Проект распространяется под лицензией MIT.";
+            MessageBox.Show(message, "Версия надстройки", 
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            return true;
+        }
+
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "AboutProgramm";
+            Ordinal = 30;
+
+            return true;
+        }
+
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+
+        /// <summary>
+        /// Получить версию надстройки
+        /// </summary>
+        /// <returns></returns>
+        private string GetVersion()
+        {
+            Version version = Assembly.GetExecutingAssembly().GetName().
+                Version;
+            return version.ToString();
+        }
+    }
+}

--- a/src/Main/AddInModule.cs
+++ b/src/Main/AddInModule.cs
@@ -1,0 +1,114 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using Eplan.EplApi.Starter;
+using System;
+using System.Windows.Forms;
+[assembly: EplanSignedAssemblyAttribute(true)]
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Точка входа в приложение, стартовый класс.
+    /// </summary>
+    public class AddInModule : IEplAddIn, IEplAddInShadowCopy
+    {
+        /// <summary>
+        /// This function is called by the framework of EPLAN, when the 
+        /// framework already has initialized its graphical user interface 
+        /// (GUI) and the add-in can start to modify the GUI.
+        /// The function only is called, if the add-in is loaded on 
+        /// system-startup.
+        /// </summary>
+        /// <returns>true, if function succeeds</returns>
+        public bool OnInitGui()
+        {
+            Eplan.EplApi.Gui.Menu oMenu = new Eplan.EplApi.Gui.Menu();
+
+            uint menuID = oMenu.AddMainMenu(
+                "EPlaner", Eplan.EplApi.Gui.Menu.MainMenuName.eMainMenuHelp,
+                "Экспорт XML для EasyServer", "SaveAsXMLAction",
+                "Экспорт XML для EasyServer", 0);
+
+            menuID = oMenu.AddMenuItem(
+                "Экспорт технологических устройств в Excel",
+                "ExportTechDevsToExcel",
+                "Экспорт технологических устройств в Excel", menuID, 1, 
+                false, true);
+
+            menuID = oMenu.AddMenuItem("Редактировать технологические объекты",
+                "ShowTechObjectsAction",
+                "Редактирование технологических объектов", menuID, 1, 
+                false, true);
+
+            menuID = oMenu.AddMenuItem("Устройства", "ShowDevicesAction",
+                "Отображение устройств", menuID, int.MaxValue, false, false);
+
+            menuID = oMenu.AddMenuItem("Операции", "ShowOperationsAction",
+                "Отображение операций", menuID, 1, false, false);
+
+            menuID = oMenu.AddMenuItem(
+                "Синхронизация названий устройств и модулей", 
+                "BindingSynchronization",
+                "Синхронизация названий устройств и модулей", menuID, 1, 
+                false, false);
+
+            menuID = oMenu.AddMenuItem("О дополнении", "AboutProgramm", "", 
+                menuID, 1, true, false);
+
+            ProjectManager.GetInstance().Init();
+
+            return true;
+        }
+
+        public bool OnRegister(ref bool bLoadOnStart)
+        {
+            bLoadOnStart = true;
+            return true;
+        }
+
+        public bool OnUnregister()
+        {
+            return true;
+        }
+
+        public bool OnInit()
+        {
+            return true;
+        }
+
+        public bool OnExit()
+        {
+            return true;
+        }
+
+        public void OnBeforeInit(string strOriginalAssemblyPath)
+        {
+            OriginalAssemblyPath = strOriginalAssemblyPath;
+        }
+
+        /// <summary>
+        /// Путь к дополнению (откуда подключена).
+        /// </summary>
+        public static string OriginalAssemblyPath;
+    }
+
+    /// <summary>    
+    /// Вспомогательные функции.
+    /// </summary>
+    public class WindowWrapper : IWin32Window
+    {
+        public WindowWrapper(IntPtr handle)
+        {
+            _hwnd = handle;
+        }
+
+        public IntPtr Handle
+        {
+            get
+            {
+                return _hwnd;
+            }
+        }
+
+        private IntPtr _hwnd;
+    }
+}

--- a/src/Main/BindingSynchronizationAction.cs
+++ b/src/Main/BindingSynchronizationAction.cs
@@ -1,0 +1,72 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using Eplan.EplApi.DataModel;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие "Синхронизация названий устройств и модулей"
+    /// </summary>
+    public class BindingSynchronization : IEplAction
+    {
+        ~BindingSynchronization()
+        {
+        }
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                Project currentProject = EProjectManager.GetInstance().
+                    GetCurrentPrj();
+                if (currentProject == null)
+                {
+                    MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                        MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+                else
+                {
+                    // Синхронизация названий модулей и устройств в текущем
+                    // проекте.
+                    ProjectManager.GetInstance().UpdateModulesBinding();
+                }
+
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN 
+        /// under this name.</param>
+        /// <param name="Ordinal">The action is registered with 
+        /// this overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "BindingSynchronization";
+            Ordinal = 17;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/ExportTechDevsToExcelAction.cs
+++ b/src/Main/ExportTechDevsToExcelAction.cs
@@ -1,0 +1,72 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using Eplan.EplApi.DataModel;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие "Экспорт технологических устройств в Excel"
+    /// </summary>
+    public class ExportTechDevsToExcel : IEplAction
+    {
+        ~ExportTechDevsToExcel()
+        {
+        }
+
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                Project currentProject = EProjectManager.GetInstance()
+                    .GetCurrentPrj();
+                if (currentProject == null)
+                {
+                    MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                        MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+                else
+                {
+                    ProjectManager.GetInstance().SaveAsExcelDescription(
+                        currentProject.ProjectDirectoryPath + @"\DOC\" +
+                        currentProject.ProjectName + ".xlsx");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this 
+        /// overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "ExportTechDevsToExcel";
+            Ordinal = 31;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled with 
+        /// information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/LoadDescriptionAction.cs
+++ b/src/Main/LoadDescriptionAction.cs
@@ -1,0 +1,74 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие загрузки описания проекта из lua файлов
+    /// </summary>
+    public class LoadDescriptionAction : IEplAction
+    {
+        ~LoadDescriptionAction()
+        {
+        }
+
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            string pVal = "no";
+            ctx.GetParameter("loadFromLua", ref pVal);
+            bool loadFromLua = true;
+            if (pVal == "no")
+            {
+                loadFromLua = false;
+            }
+
+            string errStr;
+
+            string projectName = EProjectManager.GetInstance()
+                .GetCurrentProjectName();
+            EProjectManager.GetInstance().CheckProjectName(ref projectName);
+
+            int res = ProjectManager.GetInstance().LoadDescription(out errStr,
+                projectName, loadFromLua);
+            if (res > 0)
+            {
+                MessageBox.Show(errStr, "EPlaner", MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this 
+        /// overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "LoadDescriptionAction";
+            Ordinal = 30;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be 
+        /// filled with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/SaveAsXMLAction.cs
+++ b/src/Main/SaveAsXMLAction.cs
@@ -1,0 +1,70 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using Eplan.EplApi.DataModel;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner.Main
+{
+    /// <summary>
+    /// Действие "Экспорт XML для EasyServer"
+    /// </summary>
+    public class SaveAsXMLAction : IEplAction
+    {
+        ~SaveAsXMLAction() { }
+
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                Project currentProject = EProjectManager.GetInstance()
+                    .GetCurrentPrj();
+                if (currentProject == null)
+                {
+                    MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                        MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    return true;
+                }
+
+                var exportForm = new XMLReporterDialog();
+                exportForm.SetProjectName(currentProject.ProjectName);
+                exportForm.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework,
+        ///when registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN 
+        /// under this name.</param>
+        /// <param name="Ordinal">The action is registered with 
+        /// this overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "SaveAsXMLAction";
+            Ordinal = 30;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/SaveDescriptionAction.cs
+++ b/src/Main/SaveDescriptionAction.cs
@@ -1,0 +1,83 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие сохранения описания проекта в lua файлы
+    /// </summary>
+    public class SaveDescriptionAction : IEplAction
+    {
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                string pVal = "no";
+                ctx.GetParameter("silentMode", ref pVal);
+                bool silentMode = false;
+                if (pVal == "yes")
+                {
+                    silentMode = true;
+                }
+
+                if (EProjectManager.GetInstance().GetCurrentPrj() == null)
+                {
+                    if (!silentMode)
+                    {
+                        MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                            MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    }
+                }
+                else
+                {
+                    string projectName = EProjectManager.GetInstance()
+                        .GetCurrentProjectName();
+                    EProjectManager.GetInstance()
+                        .CheckProjectName(ref projectName);
+                    string path = ProjectManager.GetInstance()
+                        .GetPtusaProjectsPath(projectName) + projectName;
+                    ProjectManager.GetInstance().SaveAsLua(projectName, path,
+                        silentMode);
+
+                    SVGStatisticsSaver.Save(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this overload 
+        /// priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "SaveDescriptionAction";
+            Ordinal = 20;
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/ShowDevicesAction.cs
+++ b/src/Main/ShowDevicesAction.cs
@@ -1,0 +1,80 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner.Main
+{
+    /// <summary>
+    /// Действие "Устройства"
+    /// </summary>
+    public class ShowDevicesAction : IEplAction
+    {
+        ~ShowDevicesAction()
+        {
+        }
+
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                if (EProjectManager.GetInstance().GetCurrentPrj() == null)
+                {
+                    MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                        MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+                else
+                {
+                    Device.DeviceType[] devTypes = null;            // All.
+                    Device.DeviceSubType[] devSubTypes = null;      // All.
+
+                    bool showChannels = true;
+                    bool showCheckboxes = false;
+                    string checkedDev = "";
+                    DFrm.OnSetNewValue OnSetNewValueFunction = null;
+                    bool isRebuiltTree = true;
+
+                    DFrm.GetInstance().ShowDevices(
+                        Device.DeviceManager.GetInstance(), devTypes, 
+                        devSubTypes, showChannels, showCheckboxes, checkedDev,
+                        OnSetNewValueFunction, isRebuiltTree);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this 
+        /// overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "ShowDevicesAction";
+            Ordinal = 21;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/ShowOperationsAction.cs
+++ b/src/Main/ShowOperationsAction.cs
@@ -1,0 +1,75 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие "Операции"
+    /// </summary>
+    public class ShowOperationsAction : IEplAction
+    {
+        ~ShowOperationsAction()
+        {
+        }
+
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            try
+            {
+                if (EProjectManager.GetInstance().GetCurrentPrj() == null)
+                {
+                    MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                        MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+                else
+                {
+
+                    ModeFrm.OnSetNewValue OnSetNewValueFunction = null;
+                    bool isRebuiltTree = true;
+
+                    ModeFrm.GetInstance().ShowModes(
+                        TechObject.TechObjectManager.GetInstance(),
+                        false, false, null, null, OnSetNewValueFunction, 
+                        isRebuiltTree);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this 
+        /// overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "ShowOperationsAction";
+            Ordinal = 36;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/Main/ShowTechObjectsAction.cs
+++ b/src/Main/ShowTechObjectsAction.cs
@@ -1,0 +1,56 @@
+﻿using Eplan.EplApi.ApplicationFramework;
+using System.Windows.Forms;
+
+namespace EasyEPlanner
+{
+    /// <summary>
+    /// Действие "Редактирование технологических объектов"
+    /// </summary>
+    public class ShowTechObjectsAction : IEplAction
+    {
+        /// <summary>
+        ///This function is called when executing the action.
+        /// </summary>
+        ///<returns>true, if the action performed successfully</returns>
+        public bool Execute(ActionCallingContext ctx)
+        {
+            if (EProjectManager.GetInstance().GetCurrentPrj() == null)
+            {
+                MessageBox.Show("Нет открытого проекта!", "EPlaner",
+                    MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            }
+            else
+            {
+                //Редактирование объектов.
+                ProjectManager.GetInstance().Edit();
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///This function is called by the application framework, when 
+        ///registering the add-in.
+        /// </summary>
+        /// <param name="Name">The action is registered in EPLAN under 
+        /// this name.</param>
+        /// <param name="Ordinal">The action is registered with this 
+        /// overload priority.</param>
+        ///<returns>true, if OnRegister succeeds</returns>
+        public bool OnRegister(ref string Name, ref int Ordinal)
+        {
+            Name = "ShowTechObjectsAction";
+            Ordinal = 21;
+            return true;
+        }
+
+        /// <summary>
+        /// Documentation function for the action.
+        /// </summary>
+        /// <param name="actionProperties"> This object needs to be filled 
+        /// with information about the action.</param>
+        public void GetActionProperties(ref ActionProperties actionProperties)
+        {
+        }
+    }
+}

--- a/src/ProjectManager.cs
+++ b/src/ProjectManager.cs
@@ -311,7 +311,7 @@ namespace EasyEPlanner
                 Logs.Clear();
                 Logs.Show();
                 Logs.AddMessage("Выполняется синхронизация..");
-                errors = ModulesBindingUpdate.GetInstance().Execute();
+                errors = ModulesBindingUpdater.GetInstance().Execute();
                 Logs.Clear();
             }
             catch (System.Exception ex)


### PR DESCRIPTION
Fixes #317.

Переименован ModulesBindingUpdate в ModulesBindingUpdater и вынесен этот класс в общий пул файлов (в корне проекта). 
main.cs был разложен на остальные классы (которые в нем содержались), они перенесены в папку Main и содержат в себе приписку "Action". Самый главный класс (точка входа в приложение) названа в соответствии с названием класса (AddInModule) и у него единственного отсутствует приписка Action.