### PR TITLE
Always set NameEplan field in UpperCase

### DIFF
--- a/src/TechObject/TechObject.cs
+++ b/src/TechObject/TechObject.cs
@@ -32,6 +32,7 @@ namespace TechObject
             /// </summary>
             public override bool SetNewValue(string newValue)
             {
+                newValue = newValue.ToUpper();
                 owner.ModifyDevNames(newValue);
                 base.SetNewValue(newValue);
                 owner.CompareEplanNames();

--- a/src/TechObject/TechObjectManager.cs
+++ b/src/TechObject/TechObjectManager.cs
@@ -267,7 +267,7 @@ namespace TechObject
             string baseTechObjectName, string attachedObjects)
         {
             TechObject obj = new TechObject(name, GetTechObjectN, techN,
-                techType, nameEplan, cooperParamNumber, NameBC, 
+                techType, nameEplan.ToUpper(), cooperParamNumber, NameBC, 
                 attachedObjects);
 
             // Установка значения базового аппарата


### PR DESCRIPTION
Fixes #321.

Т.к в EPLAN поле ОУ всегда задается заглавными буквами, то целесообразно в надстройке не иметь возможности писать прописными. Теперь при считывании (Если было написано что-то прописными) будет автоматически преобразовано в заглавные, а также привводе в полу "ОУ" данных строчными буквами, они будут преобразованы в заглавные.