### PR TITLE
Renaming equipment after replacing in object

### DIFF
--- a/src/TechObject/TechObject.cs
+++ b/src/TechObject/TechObject.cs
@@ -435,6 +435,7 @@ namespace TechObject
             clone.modes.ModifyRestrictObj(oldObjN, newObjN);
 
             clone.equipment = equipment.Clone(clone);
+            clone.equipment.ModifyDevNames();
 
             clone.SetItems();
             return clone;

--- a/src/TechObject/TechObjectManager.cs
+++ b/src/TechObject/TechObjectManager.cs
@@ -748,6 +748,7 @@ namespace TechObject
                 objects.Add(newObject);
 
                 newObject.ChangeCrossRestriction();
+                newObject.Equipment.ModifyDevNames();
 
                 return newObject;
             }
@@ -819,7 +820,7 @@ namespace TechObject
             else
             {
                 newTechObject =
-                    new TechObject("Мастер", GetTechObjectN, 1, 1, "Master", 
+                    new TechObject("Мастер", GetTechObjectN, 1, 1, "MASTER", 
                     -1, "MasterObj", "");
             }
 


### PR DESCRIPTION
Fixes #323.

В метод Clone (используемый при вставке и замене) добавлен метод ModifyDevNames. Теперь все переименовывается. Скорректировано название самого первого объекта "Мастер", его ОУ теперь в верхнем регистре.