### PR TITLE
Unit-tests for devices parameters sequence

### DIFF
--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/AI.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/AI.Test.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Tests
@@ -40,6 +41,17 @@ namespace Tests
             device.SetParameter("P_MIN_V", value1);
             device.SetParameter("P_MAX_V", value2);
             Assert.AreEqual(expected, device.GetRange());
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -125,6 +137,37 @@ namespace Tests
 			    new object[] {$"", "AI_VIRT", 4.0, 8.0, GetRandomAIDevice()},
 			    new object[] {$"", "Incorrect", 7.0, 9.0, GetRandomAIDevice()},
 			};
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_C0", "P_MIN_V", "P_MAX_V" },
+                    "",
+                    GetRandomAIDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_MIN_V", "P_MAX_V" },
+                    "AI",
+                    GetRandomAIDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "AI_VIRT",
+                    GetRandomAIDevice()
+                },
+            };
         }
 
         /// <summary>

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/AO.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/AO.Test.cs
@@ -44,7 +44,6 @@ namespace Tests
         }
 
         [TestCaseSource(nameof(ParametersTestData))]
-
         public void ParametersTest(string[] parametersSequence, string subType,
             Device.IODevice device)
         {

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/AO.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/AO.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Tests
 {
@@ -40,6 +41,18 @@ namespace Tests
             device.SetParameter("P_MIN_V", value1);
             device.SetParameter("P_MAX_V", value2);
             Assert.AreEqual(expected, device.GetRange());
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -129,6 +142,37 @@ namespace Tests
                     GetRandomAODevice()},
                 new object[] {$"", "AO_VIRT", 4.0, 8.0, GetRandomAODevice()},
                 new object[] {$"", "Incorrect", 7.0, 9.0, GetRandomAODevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_MIN_V", "P_MAX_V" },
+                    "AO",
+                    GetRandomAODevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_MIN_V", "P_MAX_V" },
+                    "",
+                    GetRandomAODevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "AO_VIRT",
+                    GetRandomAODevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/DI.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/DI.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -98,6 +110,37 @@ namespace Tests
                 new object[] {exportForDI, "DI", GetRandomDIDevice()},
                 new object[] {exportForVirtDI, "DI_VIRT", GetRandomDIDevice()},
                 new object[] {null, "Incorrect", GetRandomDIDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "DI",
+                    GetRandomDIDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "",
+                    GetRandomDIDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DI_VIRT",
+                    GetRandomDIDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/DO.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/DO.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -91,6 +103,37 @@ namespace Tests
                 new object[] {exportForDO, "DO", GetRandomDODevice()},
                 new object[] {exportForDO, "DO_VIRT", GetRandomDODevice()},
                 new object[] {exportForDO, "Incorrect", GetRandomDODevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "DO",
+                    GetRandomDODevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "",
+                    GetRandomDODevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DO_VIRT",
+                    GetRandomDODevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/FQT.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/FQT.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -43,6 +44,16 @@ namespace Tests
             Assert.AreEqual(expected, device.GetRange());
         }
 
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
+        }
         /// <summary>
         /// 1 - Ожидаемое значение подтипа,
         /// 2 - Задаваемое значение подтипа,
@@ -179,6 +190,42 @@ namespace Tests
             };
         }
 
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "FQT",
+                    GetRandomFQTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_MIN_F", "P_MAX_F", "P_C0", "P_DT" },
+                    "FQT_F",
+                    GetRandomFQTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_MIN_F", "P_MAX_F", "P_C0", "P_DT" },
+                    "FQT_F_OK",
+                    GetRandomFQTDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "FQT_VIRT",
+                    GetRandomFQTDevice()
+                },
+            };
+        }
         /// <summary>
         /// Генератор FQT устройств
         /// </summary>

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/FS.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/FS.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -23,6 +24,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -59,6 +71,31 @@ namespace Tests
             {
                 new object[] {exportForFS, "", GetRandomFSDevice()},
                 new object[] {exportForFS, "FS", GetRandomFSDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "FS",
+                    GetRandomFSDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "",
+                    GetRandomFSDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/GS.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/GS.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -23,6 +24,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -59,6 +71,31 @@ namespace Tests
             {
                 new object[] {exportForFS, "", GetRandomGSDevice()},
                 new object[] {exportForFS, "GS", GetRandomGSDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "GS",
+                    GetRandomGSDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "",
+                    GetRandomGSDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/HA.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/HA.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -23,6 +24,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -58,6 +70,31 @@ namespace Tests
             {
                 new object[] {exportForFS, "", GetRandomHADevice()},
                 new object[] {exportForFS, "HA", GetRandomHADevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "HA",
+                    GetRandomHADevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "",
+                    GetRandomHADevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/HL.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/HL.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -24,6 +25,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -60,6 +72,31 @@ namespace Tests
             {
                 new object[] {exportForHL, "", GetRandomHLDevice()},
                 new object[] {exportForHL, "HL", GetRandomHLDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "HL",
+                    GetRandomHLDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "",
+                    GetRandomHLDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/LS.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/LS.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -39,6 +40,17 @@ namespace Tests
         {
             device.SetSubType(subType);
             Assert.AreEqual(expected, device.GetConnectionType());
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -144,6 +156,49 @@ namespace Tests
                 new object[] {$"", "", GetRandomLSDevice()},
                 new object[] {$"", "Incorrect", GetRandomLSDevice()},
                 new object[] {$"", "LS_VIRT", GetRandomLSDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "LS_MIN",
+                    GetRandomLSDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "LS_MAX",
+                    GetRandomLSDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "LS_VIRT",
+                    GetRandomLSDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "LS_IOLINK_MIN",
+                    GetRandomLSDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_DT" },
+                    "LS_IOLINK_MAX",
+                    GetRandomLSDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/LT.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/LT.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -165,6 +177,58 @@ namespace Tests
                 new object[] {exportForLTVirt, "LT_VIRT", GetRandomLTDevice()},
                 new object[] {null, "Incorrect", GetRandomLTDevice()},
                 new object[] {null, "", GetRandomLTDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR" },
+                    "LT",
+                    GetRandomLTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR", "P_MAX_P", "P_R" },
+                    "LT_CYL",
+                    GetRandomLTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR", "P_MAX_P", "P_R", 
+                        "P_H_CONE" },
+                    "LT_CONE",
+                    GetRandomLTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR", "P_MAX_P", "P_R", 
+                        "P_H_TRUNC" },
+                    "LT_TRUNC",
+                    GetRandomLTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR", "P_MAX_P", "P_R",
+                        "P_H_CONE" },
+                    "LT_IOLINK",
+                    GetRandomLTDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "LT_VIRT",
+                    GetRandomLTDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/M.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/M.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -148,6 +160,73 @@ namespace Tests
                 new object[] {exportForMATV, "M_ATV", GetRandomMDevice()},
                 new object[] {null, "Incorrect", GetRandomMDevice()},
                 new object[] {null, "", GetRandomMDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_FREQ",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV_FREQ",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV_2",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV_FREQ_2",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV_2_ERROR",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_REV_FREQ_2_ERROR",
+                    GetRandomMDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME" },
+                    "M_ATV",
+                    GetRandomMDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/PT.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/PT.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -41,6 +42,17 @@ namespace Tests
             device.SetParameter("P_MIN_V", value1);
             device.SetParameter("P_MAX_V", value2);
             Assert.AreEqual(expected, device.GetRange());
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -148,6 +160,37 @@ namespace Tests
                     GetRandomPTDevice()},
                 new object[] {$"", "", 4.0, 8.0, GetRandomPTDevice()},
                 new object[] {$"", "Incorrect", 7.0, 9.0, GetRandomPTDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_C0", "P_MIN_V", "P_MAX_V" },
+                    "PT",
+                    GetRandomPTDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "PT_IOLINK",
+                    GetRandomPTDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DEV_SPAE",
+                    GetRandomPTDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/QT.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/QT.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -41,6 +42,17 @@ namespace Tests
             device.SetParameter("P_MIN_V", value1);
             device.SetParameter("P_MAX_V", value2);
             Assert.AreEqual(expected, device.GetRange());
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -154,6 +166,37 @@ namespace Tests
                     GetRandomQTDevice()},
                 new object[] {$"", "", 4.0, 8.0, GetRandomQTDevice()},
                 new object[] {$"", "Incorrect", 7.0, 9.0, GetRandomQTDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_C0", "P_MIN_V", "P_MAX_V" },
+                    "QT",
+                    GetRandomQTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_MIN_V", "P_MAX_V" },
+                    "QT_OK",
+                    GetRandomQTDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "QT_IOLINK",
+                    GetRandomQTDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/SB.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/SB.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -23,6 +24,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -59,6 +71,31 @@ namespace Tests
             {
                 new object[] {exportForSB, "", GetRandomSBDevice()},
                 new object[] {exportForSB, "SB", GetRandomSBDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "SB",
+                    GetRandomSBDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "",
+                    GetRandomSBDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/TE.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/TE.Test.cs
@@ -35,7 +35,6 @@ namespace Tests
         }
 
         [TestCaseSource(nameof(ParametersTestData))]
-
         public void ParametersTest(string[] parametersSequence, string subType, 
             Device.IODevice device)
         {

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/TE.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/TE.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,18 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+
+        public void ParametersTest(string[] parametersSequence, string subType, 
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -93,6 +106,31 @@ namespace Tests
                 new object[] {exportForTE, "TE", GetRandomTEDevice()},
                 new object[] {exportForTE, "TE_IOLINK", GetRandomTEDevice()},
                 new object[] {null, "Incorrect", GetRandomTEDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[] 
+                { 
+                    new string[] { "P_C0", "P_ERR" }, 
+                    "TE", 
+                    GetRandomTEDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_C0", "P_ERR" },
+                    "TE_IOLINK",
+                    GetRandomTEDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/V.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/V.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -31,6 +32,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -203,6 +215,109 @@ namespace Tests
                     GetRandomVDevice()},
                 new object[] {null, "Incorrect", GetRandomVDevice()},
                 new object[] {null, "", GetRandomVDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "V_DO1",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "V_DO2",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_DO1_DI1_FB_OFF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_DO1_DI2",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_DO2_DI2",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_DO2_DI2_BISTABLE",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_MIXPROOF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_IOLINK_MIXPROOF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_AS_MIXPROOF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_BOTTOM_MIXPROOF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_AS_DO1_DI2",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_IOLINK_DO1_DI2",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "V_IOLINK_VTUG_DO1",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_IOLINK_VTUG_DO1_FB_OFF",
+                    GetRandomVDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_ON_TIME", "P_FB" },
+                    "V_IOLINK_VTUG_DO1_FB_ON",
+                    GetRandomVDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/VC.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/VC.Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -23,6 +24,17 @@ namespace Tests
             device.SetSubType(subType);
             Assert.AreEqual(expectedProperties, device.GetDeviceProperties(
                 device.DeviceType, device.DeviceSubType));
+        }
+
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
         }
 
         /// <summary>
@@ -59,6 +71,31 @@ namespace Tests
             {
                 new object[] {exportForVC, "", GetRandomVCDevice()},
                 new object[] {exportForVC, "VC", GetRandomVCDevice()},
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "VC",
+                    GetRandomVCDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "",
+                    GetRandomVCDevice()
+                },
             };
         }
 

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/WT.Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/WT.Test.cs
@@ -67,6 +67,31 @@ namespace Tests
         }
 
         /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[] { "P_NOMINAL_W", "P_RKP", "P_C0", "P_DT" },
+                    "WT",
+                    GetRandomWTDevice()
+                },
+                new object[]
+                {
+                    new string[] { "P_NOMINAL_W", "P_RKP", "P_C0", "P_DT" },
+                    "",
+                    GetRandomWTDevice()
+                },
+            };
+        }
+
+        /// <summary>
         /// Генератор WT устройств
         /// </summary>
         /// <returns></returns>

--- a/EasyEplanner.Tests/Device.Test/IODevice.Test/Y(DEV_VTUG).Test.cs
+++ b/EasyEplanner.Tests/Device.Test/IODevice.Test/Y(DEV_VTUG).Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Tests
@@ -15,6 +16,17 @@ namespace Tests
             Assert.AreEqual(expectedSubType, device.DeviceSubType);
         }
 
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
+        }
+
         /// <summary>
         /// 1 - Ожидаемое значение подтипа,
         /// 2 - Задаваемое значение подтипа,
@@ -26,15 +38,46 @@ namespace Tests
             return new object[]
             {
                 new object[] { Device.DeviceSubType.DEV_VTUG_8, "DEV_VTUG_8",
-                    GetRandomYDevice() },
+                    GetRandomDEV_VTUGDevice() },
                 new object[] { Device.DeviceSubType.DEV_VTUG_16, "DEV_VTUG_16",
-                    GetRandomYDevice() },
+                    GetRandomDEV_VTUGDevice() },
                 new object[] { Device.DeviceSubType.DEV_VTUG_24, "DEV_VTUG_24",
-                    GetRandomYDevice() },
+                    GetRandomDEV_VTUGDevice() },
                 new object[] { Device.DeviceSubType.NONE, "",
-                    GetRandomYDevice() },
+                    GetRandomDEV_VTUGDevice() },
                 new object[] { Device.DeviceSubType.NONE, "Incorrect",
-                    GetRandomYDevice() },
+                    GetRandomDEV_VTUGDevice() },
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_8",
+                    GetRandomDEV_VTUGDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_16",
+                    GetRandomDEV_VTUGDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_24",
+                    GetRandomDEV_VTUGDevice()
+                },
             };
         }
 
@@ -42,7 +85,7 @@ namespace Tests
         /// Генератор DEV_VTUG устройств
         /// </summary>
         /// <returns></returns>
-        public static Device.IODevice GetRandomYDevice()
+        public static Device.IODevice GetRandomDEV_VTUGDevice()
         {
             var randomizer = new Random();
             int value = randomizer.Next(1, 3);
@@ -74,6 +117,17 @@ namespace Tests
             Assert.AreEqual(expectedSubType, device.DeviceSubType);
         }
 
+        [TestCaseSource(nameof(ParametersTestData))]
+        public void ParametersTest(string[] parametersSequence, string subType,
+            Device.IODevice device)
+        {
+            device.SetSubType(subType);
+            string[] actualParametersSequence = device.Parameters
+                .Select(x => x.Key)
+                .ToArray();
+            Assert.AreEqual(parametersSequence, actualParametersSequence);
+        }
+
         /// <summary>
         /// 1 - Ожидаемое значение подтипа,
         /// 2 - Задаваемое значение подтипа,
@@ -94,6 +148,37 @@ namespace Tests
                     GetRandomYDevice() },
                 new object[] { Device.DeviceSubType.NONE, "Incorrect",
                     GetRandomYDevice() },
+            };
+        }
+
+        /// <summary>
+        /// 1 - Параметры в том порядке, который нужен
+        /// 2 - Подтип устройства
+        /// 3 - Устройство
+        /// </summary>
+        /// <returns></returns>
+        public static object[] ParametersTestData()
+        {
+            return new object[]
+            {
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_8",
+                    GetRandomYDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_16",
+                    GetRandomYDevice()
+                },
+                new object[]
+                {
+                    new string[0],
+                    "DEV_VTUG_24",
+                    GetRandomYDevice()
+                },
             };
         }
 

--- a/src/Device/IODevice.cs
+++ b/src/Device/IODevice.cs
@@ -703,6 +703,17 @@ namespace Device
         }
 
         /// <summary>
+        /// Получить параметры устройства.
+        /// </summary>
+        public Dictionary<string, object> Parameters
+        {
+            get
+            {
+                return parameters;
+            }
+        }
+
+        /// <summary>
         /// Свойство содержащее изделие, которое используется для устройства
         /// </summary>
         public string ArticleName { get; set; } = "";


### PR DESCRIPTION
Добавлены юнит-тесты для тестирования корректной последовательности параметров у устройств. Так как у нас параметры по индексам, то это важно.