### PR TITLE
Fixed error after deleting object when highlighting enabled

### DIFF
--- a/src/EditorCtrl.cs
+++ b/src/EditorCtrl.cs
@@ -778,7 +778,7 @@ namespace Editor
                 ITreeViewItem item = GetActiveItem();
 
                 ProjectManager.GetInstance().RemoveHighLighting();
-                if (item.IsDrawOnEplanPage)
+                if (item != null && item.IsDrawOnEplanPage)
                 {
                     ProjectManager.GetInstance().SetHighLighting(
                         item.GetObjectToDrawOnEplanPage());


### PR DESCRIPTION
Пофикшен баг, когда при включенной подсветке устройств удаляется последний объект и вываливалась ошибка. Найдено случайно.