### PR TITLE
Corrected automatic equipment bind

### DIFF
--- a/src/TechObject/Equipment.cs
+++ b/src/TechObject/Equipment.cs
@@ -191,7 +191,8 @@ namespace TechObject
         private void SetDeviceAutomatically(BaseParameter equipment)
         {
             string currentValue = equipment.Value;
-            if (currentValue == equipment.DefaultValue)
+            if (equipment.DefaultValue != "" && 
+                currentValue == equipment.DefaultValue)
             {
                 string deviceName = owner.NameEplan + owner.TechNumber +
                     equipment.DefaultValue;

--- a/src/TechObject/Equipment.cs
+++ b/src/TechObject/Equipment.cs
@@ -201,6 +201,10 @@ namespace TechObject
                 {
                     equipment.SetNewValue(deviceName);
                 }
+                else
+                {
+                    equipment.SetNewValue("");
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #471 

**Решение**
Если во время автоматической привязки не обнаружили устройство, то обнуляем его. Если надо добавить новое, то мы либо вводим стандартное значение, что бы сработала привязка автоматически, либо руками добавляем (через редактор тоже можно). Устройства с пустыми стандартными значениями в автоматической привязке не участвуют.