### PR TITLE
Fix error with loading files and libs when they don't exist

### DIFF
--- a/src/ProjectManager.cs
+++ b/src/ProjectManager.cs
@@ -271,6 +271,8 @@ namespace EasyEPlanner
         /// </summary>
         public void Init()
         {
+            CheckLibsAndFiles();
+
             editor = Editor.Editor.GetInstance();
             techObjectManager = TechObjectManager.GetInstance();
             Logs.Init(new LogFrm());           
@@ -279,7 +281,13 @@ namespace EasyEPlanner
             projectConfiguration = ProjectConfiguration.GetInstance();
             EProjectManager.GetInstance();
             BaseTechObjectManager.GetInstance();
+        }
 
+        /// <summary>
+        /// Проверка доступности библиотек и файлов для надстройки.
+        /// </summary>
+        private void CheckLibsAndFiles()
+        {
             CheckExcelLibs();
             CopySystemFiles();
         }


### PR DESCRIPTION
Fixes #572.

Перенесли проверку и загрузку файлов и библиотек до начала чтения данных проекта. В этом и была ошибка. Проверялось после загрузки всего проекта, а надо перед.