### PR TITLE
Fix opening "Devices" and "Operations" window after reopen project

### DIFF
--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -455,7 +455,10 @@ namespace Editor
             editorTView.FinishCellEdit();
             editorTView.ClearObjects();
 
-            edit_toolStripButton_Click(this, new EventArgs());
+            if(Editable)
+            {
+                edit_toolStripButton_Click(this, new EventArgs());
+            }
 
             PI.UnhookWindowsHookEx(dialogHookPtr);
             PI.UnhookWindowsHookEx(globalKeyboardHookPtr);

--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -455,6 +455,8 @@ namespace Editor
             editorTView.FinishCellEdit();
             editorTView.ClearObjects();
 
+            edit_toolStripButton_Click(this, new EventArgs());
+
             PI.UnhookWindowsHookEx(dialogHookPtr);
             PI.UnhookWindowsHookEx(globalKeyboardHookPtr);
 


### PR DESCRIPTION
Fixes #594.

Отключаем режим редактирования при закрытии проекта.