### PR TITLE
Corrected replace operation with restrictions

### DIFF
--- a/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
@@ -427,6 +427,12 @@ namespace TechObject
                 }
 
                 ChangeRestrictionModeOwner(newMode);
+                int newN = TechObjectManager.GetInstance()
+                    .GetTechObjectN(Owner);
+                int oldN = TechObjectManager.GetInstance()
+                    .GetTechObjectN(copyMode.Owner.Owner);
+                newMode.ModifyRestrictObj(oldN, newN);
+
                 newMode.ChangeCrossRestriction(mode);
                 return newMode;
             }


### PR DESCRIPTION
При копировании объекта все ОК, а при копировании операции не менялся номер объекта в ограничениях и были сайд эффекты.