### PR TITLE
Remove deleting file if model empty

### DIFF
--- a/src/InterprojectExchange/InterprojectExchangeSaver.cs
+++ b/src/InterprojectExchange/InterprojectExchangeSaver.cs
@@ -125,9 +125,7 @@ namespace InterprojectExchange
         /// <param name="model">Модель</param>
         private void WriteAdvancedModel(IProjectModel model)
         {
-            bool deleteModel = (model.ReceiverSignals.Count == 0 &&
-                model.SourceSignals.Count == 0) ||
-                model.MarkedForDelete;
+            bool deleteModel = model.MarkedForDelete;
             if (deleteModel)
             {
                 DeleteSharedFile(model.ProjectName);


### PR DESCRIPTION
There was the problem, when user have no signals in model and we shouldn't delete file, only delete data linked with empty project.