### PR TITLE
Bugfix automatic set base steps

### DIFF
--- a/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
@@ -692,6 +692,7 @@ namespace TechObject
             {
                 var stateSteps = baseOperation
                     .GetStateBaseSteps(state.Type)
+                    .Where(x => x.DefaultPosition > 0)
                     .OrderBy(x => x.DefaultPosition);
                 foreach(var baseStep in stateSteps)
                 {


### PR DESCRIPTION
There is a bug. After add new object we will have wrong sequence of steps (offset increased by 1)