### PR TITLE
Support F device in interproject exchange

### DIFF
--- a/src/Lua/sys_devices_mock_generator.lua
+++ b/src/Lua/sys_devices_mock_generator.lua
@@ -2,6 +2,10 @@
 devs = {}
 devsidx = 0
 
+function DEVICE(dev)
+	return devs[dev][1] or { }
+end
+
 function V(dev)
 	devs[devsidx] = {dev, 'V'}
 	devsidx = devsidx + 1
@@ -116,12 +120,14 @@ function AI(dev)
 	return dev
 end
 
-function DEVICE(dev)
-	return devs[dev][1] or { }
-end
-
 function C(dev)
 	devs[devsidx] = {dev, "C"}
 	devsidx = devsidx + 1
+	return dev
+end
+
+function F(dev)
+	devs[devsidx] = {dev, "F"}
+	devsIdx = devsidx + 1
 	return dev
 end


### PR DESCRIPTION
There is an error in interproject exchange, because the exhange have no data about F device mock.