### PR TITLE
Correct getting device from EplanName for PID errors

### DIFF
--- a/src/Device/DeviceManager.cs
+++ b/src/Device/DeviceManager.cs
@@ -162,7 +162,7 @@ namespace Device
                     object value = property.Value;
                     if(value != null)
                     {
-                        var devInPropery = GetDevice(
+                        var devInPropery = GetDeviceByEplanName(
                             value.ToString().Trim(new char[] { '\'' }));
                         if (devInPropery.Description == cap)
                         {

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "OJSC Savushkin product" )]
 [assembly: AssemblyProduct( "EPLAN project designer" )]
-[assembly: AssemblyCopyright( "Copyright ©  2012 - 2020" )]
+[assembly: AssemblyCopyright( "Copyright ©  2012 - 2021" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2021.05.*")]
-[assembly: AssemblyFileVersion("2021.05.0.0")]
+[assembly: AssemblyVersion("2021.06.*")]
+[assembly: AssemblyFileVersion("2021.06.0.0")]


### PR DESCRIPTION
Fixes #845 
Но в последствии надо переделать devName и devNumber. Это главная причина некорректной работы GetDevice. Изменений будет много, поэтому пока закрываем ошибку так.