### PR TITLE
Correct behavior in InterProjectExchange if user ignored errors during loading data

### DIFF
--- a/src/InterprojectExchange/InterprojectExchangeSaver.cs
+++ b/src/InterprojectExchange/InterprojectExchangeSaver.cs
@@ -582,8 +582,17 @@ namespace InterprojectExchange
             var model = interprojectExchange.GetModel(projectName);
             string path = Path.Combine(model.PathToProject, 
                 projectName, SharedFile);
-            using (var writer = new StreamWriter(path, false,
-                EasyEPlanner.EncodingDetector.DetectFileEncoding(path)))
+
+            if(!File.Exists(path))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                var openedFileStream = File.Create(path);
+                openedFileStream.Close();
+            }
+
+            System.Text.Encoding encoding = EasyEPlanner.EncodingDetector
+                    .DetectFileEncoding(path);
+            using (var writer = new StreamWriter(path, false, encoding))
             {
                 foreach (string line in sharedFileData)
                 {

--- a/src/InterprojectExchange/InterprojectExchangeStarter.cs
+++ b/src/InterprojectExchange/InterprojectExchangeStarter.cs
@@ -42,6 +42,7 @@ namespace InterprojectExchange
         public void Start()
         {
             interprojectExchange.Owner = this;
+            form = new InterprojectExchangeForm();
             bool isReadSignals = UpdateDevices();
             bool isLoadData = LoadCurrentInterprojectExchange(isReadSignals);
             ShowForm(isLoadData);
@@ -245,9 +246,8 @@ namespace InterprojectExchange
             }
             else
             {
-                MessageBox.Show($"Не найден файл main.io.lua проекта" +
-                    $" \"{projName}\"", "Ошибка", MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                form.ShowErrorMessage($"Не найден файл main.io.lua проекта" +
+                    $" \"{projName}\"");
             }
         }
 


### PR DESCRIPTION
If project was not found and we have project data and main project we shouldn't save it. But users can ignore these errors and we will get crash of EPLAN. Now we just save empty files for advanced project and no changes for main project.