### PR TITLE
Update bind because of new info from EPLAN

### DIFF
--- a/src/Configuration/DeviceBindingReader.cs
+++ b/src/Configuration/DeviceBindingReader.cs
@@ -324,8 +324,18 @@ namespace EasyEPlanner
         private string ReplaceClampCommentInComment(string comment,
             string foundClampComment)
         {
-            string replaced = Regex.Replace(comment, foundClampComment,
-                    string.Empty, RegexOptions.IgnoreCase);
+            bool invalidComment =
+                comment == CommonConst.NewLineWithCarriageReturn ||
+                comment == CommonConst.NewLine ||
+                comment == string.Empty;
+            if (invalidComment)
+            {
+                return string.Empty;
+            }
+
+            string replaced = Regex.Replace(comment,
+                Regex.Escape(foundClampComment), string.Empty,
+                RegexOptions.IgnoreCase);
             replaced = replaced.Replace(CommonConst.NewLine, ". ").Trim();
             if (replaced.Length > 0 && replaced[replaced.Length - 1] != '.')
             {

--- a/src/StaticHelper/DeviceBindingHelper.cs
+++ b/src/StaticHelper/DeviceBindingHelper.cs
@@ -67,20 +67,28 @@ namespace StaticHelper
 
         public static Match FindCorrectClampCommentMatch(string comment)
         {
-            string[] splitBySeparator = comment.Split(
-                new string[] { CommonConst.NewLineWithCarriageReturn },
+            string replaceCarriageToNewLine = Regex.Replace(comment,
+                CommonConst.NewLineWithCarriageReturn,
+                CommonConst.NewLine);
+            string[] splitBySeparator = replaceCarriageToNewLine.Split(
+                new string[] { CommonConst.NewLine },
                 StringSplitOptions.RemoveEmptyEntries);
 
             int arrEndIndex = splitBySeparator.Length - 1;
-            for (int i = arrEndIndex; i > 0; i++)
+            int maxDeep = 2;
+            for (int i = arrEndIndex; i >= 0; i--)
             {
-                var match = Regex.Match(splitBySeparator[i],
+                if (maxDeep > 0)
+                {
+                    var match = Regex.Match(splitBySeparator[i],
                     IODevice.IOChannel.ChannelCommentPattern,
                     RegexOptions.IgnoreCase);
-                if (match.Value.Length == splitBySeparator[i].Length)
-                {
-                    return match;
+                    if (match.Value.Length == splitBySeparator[i].Length)
+                    {
+                        return match;
+                    }
                 }
+                maxDeep--;
             }
 
             return Match.Empty;


### PR DESCRIPTION
EPLAN deleter \r symbol after copy pages..
#893 

Now we just replace \r\n to \n and check last 2 rows (if exists), because only 2 last rows contains clamp name definition (we have IO-Link clamp definition in this last rows sometimes)