### PR TITLE
Delete version control folders if they were added to shadow assembly

### DIFF
--- a/src/ProjectManager.cs
+++ b/src/ProjectManager.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Windows.Forms;
 using TechObject;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EasyEPlanner
 {
@@ -291,6 +292,7 @@ namespace EasyEPlanner
         /// </summary>
         private void CheckLibsAndFiles()
         {
+            DeleteVersionControlDirectoriesInShadowAssembly();
             CheckExcelLibs();
             CopySystemFiles();
         }
@@ -722,6 +724,31 @@ namespace EasyEPlanner
                 string pathToFile = Path.Combine(SystemFilesPath,
                     systemFile.Name);
                 systemFile.CopyTo(pathToFile, true);
+            }
+        }
+
+        private void DeleteVersionControlDirectoriesInShadowAssembly()
+        {
+            var deletingDirectories = new string[] { ".svn", ".git" };
+            foreach(var dir in deletingDirectories)
+            {
+                string dirPath = Path.Combine(AssemblyPath, dir);
+                bool dirExists = Directory.Exists(dirPath);
+                if (dirExists)
+                {
+                    Task.Run(() =>
+                    {
+                        var directoryInfo = new DirectoryInfo(dirPath);
+                        FileInfo[] files = directoryInfo
+                            .GetFiles("*.*", SearchOption.AllDirectories);
+                        foreach (var file in files)
+                        {
+                            file.IsReadOnly = false;
+                        }
+
+                        directoryInfo.Delete(true);
+                    });
+                }
             }
         }
 

--- a/src/ProjectManager.cs
+++ b/src/ProjectManager.cs
@@ -306,10 +306,12 @@ namespace EasyEPlanner
             string shadowAssemblyPath = GetShadowAssemblyPath();
 
             var pathsToControlVersionDirs = new List<string>();
-            pathsToControlVersionDirs.AddRange(Directory.GetDirectories(
-                shadowAssemblyPath, ".svn", SearchOption.AllDirectories));
-            pathsToControlVersionDirs.AddRange(Directory.GetDirectories(
-                shadowAssemblyPath, ".git", SearchOption.AllDirectories));
+            var checkingDirectories = new string[] { ".svn", ".git" };
+            foreach(var dir in checkingDirectories)
+            {
+                pathsToControlVersionDirs.AddRange(Directory.GetDirectories(
+                    shadowAssemblyPath, dir, SearchOption.AllDirectories));
+            }
 
             foreach (var pathToCVDir in pathsToControlVersionDirs)
             {
@@ -325,10 +327,11 @@ namespace EasyEPlanner
 
         private string GetShadowAssemblyPath()
         {
+            int pathOffset = 3;
             List<string> pathParts = AssemblyPath
                 .Split('\\')
                 .ToList();
-            pathParts.RemoveRange(pathParts.Count - 3, 3);
+            pathParts.RemoveRange(pathParts.Count - pathOffset, pathOffset);
             var pathToShadowAssembly = string.Join("\\", pathParts);
 
             return pathToShadowAssembly;

--- a/src/ProjectManager.cs
+++ b/src/ProjectManager.cs
@@ -292,12 +292,12 @@ namespace EasyEPlanner
         /// </summary>
         private void CheckLibsAndFiles()
         {
-            DeleteVersionControlDirectoriesInShadowAssembly();
+            MarkForDeleteVersionControlDirectoriesInShadowAssembly();
             CheckExcelLibs();
             CopySystemFiles();
         }
 
-        private void DeleteVersionControlDirectoriesInShadowAssembly()
+        private void MarkForDeleteVersionControlDirectoriesInShadowAssembly()
         {
             var deletingDirectories = new string[] { ".svn", ".git" };
             foreach (var dir in deletingDirectories)
@@ -315,8 +315,6 @@ namespace EasyEPlanner
                         {
                             file.IsReadOnly = false;
                         }
-
-                        directoryInfo.Delete(true);
                     });
                 }
             }


### PR DESCRIPTION
During Add-In initalization EPLAN adds hidden readonly version control directories (git or svn, doesn't matter). After unregistering and closing or opening EPLAN again, those directories are never deleted. We have memory leak with lots of files. This problem was found after half a year after upgrading EPLAN.