### PR TITLE
Processing base operation parameters after loading tech object parameters

### DIFF
--- a/src/TechObject/Base/BaseOperation.cs
+++ b/src/TechObject/Base/BaseOperation.cs
@@ -420,10 +420,7 @@ namespace TechObject
             string errors = string.Empty;
             foreach (var property in Properties)
             {
-                if (property is MainAggregateParameter)
-                {
-                    (property as MainAggregateParameter).Check();
-                }
+                property.Check();
 
                 bool notStub = !property.Value.ToLower()
                     .Contains(StaticHelper.CommonConst.StubForCells

--- a/src/TechObject/Base/BaseParameter.cs
+++ b/src/TechObject/Base/BaseParameter.cs
@@ -520,6 +520,14 @@ namespace TechObject
             return null;
         }
 
+        public virtual void Check()
+        {
+            if (!IsEmpty && !Disabled)
+            {
+                ProcessValue(Value);
+            }
+        }
+
         /// <summary>
         /// Текущий тип значений, принимаемый параметром
         /// </summary>

--- a/src/TechObject/Base/BaseParameter.cs
+++ b/src/TechObject/Base/BaseParameter.cs
@@ -209,13 +209,18 @@ namespace TechObject
         private void ProcessValue(object value)
         {
             string valueStr = value.ToString();
-            currentValueType = GetParameterValueType(valueStr);
+            SetParameterValueType(valueStr);
             devicesIndexes.Clear();
             if (OnlyDevicesInParameter)
             {
                 List<string> splittedDevices = valueStr.Split(' ').ToList();
                 devicesIndexes.AddRange(GetDevicesIndexes(splittedDevices));
             }
+        }
+
+        private void SetParameterValueType(string valueStr)
+        {
+            currentValueType = GetParameterValueType(valueStr);
         }
 
         /// <summary>
@@ -524,7 +529,7 @@ namespace TechObject
         {
             if (!IsEmpty && !Disabled)
             {
-                ProcessValue(Value);
+                SetParameterValueType(Value);
             }
         }
 

--- a/src/TechObject/Base/Properties/MainAggregateParameter.cs
+++ b/src/TechObject/Base/Properties/MainAggregateParameter.cs
@@ -23,7 +23,7 @@ namespace TechObject
         /// <summary>
         /// Проверка параметра
         /// </summary>
-        public void Check()
+        public override void Check()
         {
             SetUpParametersVisibility();
         }


### PR DESCRIPTION
We couldn't load object operations before object properties, cause we couldn't load binding between properties and modes, and vice vbersa. Then, I found a solution. After loading any of them i have been running processing properties again and then I got right behavior.