### PR TITLE
Fix build GitHub action

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
The workflow was broken in the sense that it did not actually build the PR, but built the latest changeset from the target repository.