### PR TITLE
Generate shared devices at runtime

### DIFF
--- a/src/InterprojectExchange/InterprojectExchangeSaver.cs
+++ b/src/InterprojectExchange/InterprojectExchangeSaver.cs
@@ -355,7 +355,14 @@ namespace InterprojectExchange
 
             foreach (var signal in signals)
             {
-                digIn += prefix + $"\"{signal}\",\n";
+                if (invertSignals)
+                {
+                    digIn += prefix + $"{signal},\n";
+                }
+                else
+                {
+                    digIn += prefix + $"__{signal},\n";
+                }
             }
 
             if (!string.IsNullOrEmpty(digIn))
@@ -392,7 +399,14 @@ namespace InterprojectExchange
 
             foreach (var signal in signals)
             {
-                digOut += prefix + $"\"{signal}\",\n";
+                if (invertSignals)
+                {
+                    digOut += prefix + $"__{signal},\n";
+                }
+                else
+                {
+                    digOut += prefix + $"{signal},\n";
+                }
             }
 
             if (!string.IsNullOrEmpty(digOut))
@@ -429,7 +443,14 @@ namespace InterprojectExchange
 
             foreach (var signal in signals)
             {
-                analogIn += prefix + $"\"{signal}\",\n";
+                if (invertSignals)
+                {
+                    analogIn += prefix + $"{signal},\n";
+                }
+                else
+                {
+                    analogIn += prefix + $"__{signal},\n";
+                }
             }
 
             if (!string.IsNullOrEmpty(analogIn))
@@ -465,7 +486,14 @@ namespace InterprojectExchange
 
             foreach (var signal in signals)
             {
-                analogOut += prefix + $"\"{signal}\",\n";
+                if (invertSignals)
+                {
+                    analogOut += prefix + $"__{signal},\n";
+                }
+                else
+                {
+                    analogOut += prefix + $"{signal},\n";
+                }
             }
 
             if (!string.IsNullOrEmpty(analogOut))

--- a/src/InterprojectExchange/InterprojectExchangeStarter.cs
+++ b/src/InterprojectExchange/InterprojectExchangeStarter.cs
@@ -254,7 +254,11 @@ namespace InterprojectExchange
             }
         }
 
-
+        /// <summary>
+        /// Инициализирует переменные с названиями стройств,
+        /// использующиеся в shared.lua 
+        /// </summary>
+        /// <param name="projectName">Имя проекта</param>
         private void GenerateSharedDevices(string projectName)
         {
             var devices = interprojectExchange.

--- a/src/InterprojectExchange/InterprojectExchangeStarter.cs
+++ b/src/InterprojectExchange/InterprojectExchangeStarter.cs
@@ -170,6 +170,7 @@ namespace InterprojectExchange
             InitLuaInstance();
             LoadScripts();
             LoadMainIOData(pathToMainProject, projName);
+            GenerateSharedDevices(projName);
             LoadCurrentProjectSharedLuaData(pathToMainProject, projName);
             interprojectExchange.MainModel.PathToProject = pathToMainProject;
 
@@ -184,6 +185,7 @@ namespace InterprojectExchange
                     LoadScripts();
                     model.Selected = true;
                     LoadMainIOData(pathToProject, alternativeProject);
+                    GenerateSharedDevices(alternativeProject);
                     LoadAdvancedProjectSharedLuaData(pathToProject,
                         alternativeProject);
                     model.Selected = false;
@@ -250,6 +252,20 @@ namespace InterprojectExchange
                 form.ShowErrorMessage($"Не найден файл main.io.lua проекта" +
                     $" \"{projName}\"");
             }
+        }
+
+
+        private void GenerateSharedDevices(string projectName)
+        {
+            var devices = interprojectExchange.
+                GetModel(projectName).Devices;
+            string devicesLua = string.Empty;
+            foreach (var device in devices)
+            {
+                devicesLua += $"{device.Name} = \"{device.Name}\"\n" +
+                    $"__{device.Name} = \"{device.Name}\"\n"; 
+            }
+            lua.DoString(devicesLua);
         }
 
         /// <summary>


### PR DESCRIPTION
- old save format `shared.lua`;
- variables for `shared.lua` are generated at runtime.