### PR TITLE
Fix modify dev obj name

### DIFF
--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Actions.Test/Action.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Actions.Test/Action.Test.cs
@@ -599,9 +599,9 @@ namespace TechObjectTests
         }
 
         [TestCase(new int[] { 1, 2, 3, 4 }, new int[] { 5, 6, 3, 4 }, 2, "TANK")]
-        [TestCase(new int[] { 1, 2, 3 }, new int[] { 3 }, 3, "TANK")]
+        [TestCase(new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 }, 3, "TANK")]
         public void ModifyDevNames_CheckGenericUpdating(int[] devIds,
-            int[] expectedDevIds, int newDevID, string techObjectName)
+            int[] expectedDevIds, int newObjID, string techObjectName)
         {
             EplanDevice.IDeviceManager deviceManager = DeviceManagerMock.DeviceManager;
             typeof(Action).GetField("deviceManager",
@@ -612,7 +612,7 @@ namespace TechObjectTests
                 null, null);
             action.DevicesIndex.AddRange(devIds);
 
-            action.ModifyDevNames(newDevID, -1, techObjectName);
+            action.ModifyDevNames(newObjID, -1, techObjectName);
 
             CollectionAssert.AreEqual(expectedDevIds, action.DevicesIndex);
         }

--- a/src/TechObject/ObjectsTree/UniversalObject/Actions/Action.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Actions/Action.cs
@@ -284,8 +284,6 @@ namespace TechObject
 
                 if (tmpDev >= 0)
                     tmpDevs[devIndex] = tmpDev;
-                else
-                    tmpDevs.RemoveAt(devIndex);
             }
 
             return tmpDevs;

--- a/src/TechObject/ObjectsTree/UniversalObject/Actions/Action.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Actions/Action.cs
@@ -223,7 +223,7 @@ namespace TechObject
                 deviceIndex = ModifyDevNamesChangeTechNumbers(newTechObjectN,
                     oldTechObjectN, techObjectName, deviceIndex);
             genericDeviceIndex = ModifyDevNamesChangeTechNumbers(newTechObjectN,
-                oldTechObjectN, techObjectName, genericDeviceIndex);
+                oldTechObjectN, techObjectName, genericDeviceIndex, true);
             deviceIndex = IndexesExclude(deviceIndex, genericDeviceIndex);
         }
 
@@ -267,7 +267,7 @@ namespace TechObject
         }
 
         private List<int> ModifyDevNamesChangeTechNumbers(int newTechObjectN,
-            int oldTechObjectN, string techObjectName, List<int> devs)
+            int oldTechObjectN, string techObjectName, List<int> devs, bool isGeneric = false)
         {
             List<int> tmpDevs = new List<int>();
             tmpDevs.AddRange(devs);
@@ -284,6 +284,8 @@ namespace TechObject
 
                 if (tmpDev >= 0)
                     tmpDevs[devIndex] = tmpDev;
+                else if (isGeneric)
+                    tmpDevs.RemoveAt(devIndex);
             }
 
             return tmpDevs;


### PR DESCRIPTION
Fixes #1399.

```ChangeLog
Изменения в модификации названий устройств: если при изменении номера объекта (1 -> 2) в объекте было привязаны устройства OBJ2x1, и при этом устройства OBJ1x1 нет в проекте, то название исходного устройства останется без изменений и не будет удалено, иначе название модифицируется по старому правилу в OBJ1x1.
```