### PR TITLE
Fix replace and paste base operations and steps

### DIFF
--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/ModesManager.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/ModesManager.Test.cs
@@ -135,16 +135,20 @@ namespace TechObject.Tests
                 Assert.AreNotSame(copied_operation_1, insertedOperation_1);
                 Assert.AreEqual(copied_operation_1.BaseOperation.LuaName, insertedOperation_1.BaseOperation.LuaName);
 
-                // Повторная вставка базовой операции 1 (canceled)
-                var insertedOperation_null = modesManager.InsertCopy(copied_operation_1) as Mode;
-                Assert.IsNull(insertedOperation_null);
+                // Повторная вставка базовой операции 1
+                insertedOperation_1 = modesManager.InsertCopy(copied_operation_1) as Mode;
+                Assert.IsNotNull(insertedOperation_1);
+                Assert.AreNotSame(copied_operation_1, insertedOperation_1);
+                Assert.AreEqual(string.Empty, insertedOperation_1.BaseOperation.LuaName);
 
-                // Вставка несуществующей базовой операции 3 (canceled)
-                insertedOperation_null = modesManager.InsertCopy(copied_operation_3) as Mode;
-                Assert.IsNull(insertedOperation_null);
+                // Вставка несуществующей базовой операции 3
+                var insertedOperation_3 = modesManager.InsertCopy(copied_operation_3) as Mode;
+                Assert.IsNotNull(insertedOperation_3);
+                Assert.AreNotSame(copied_operation_3, insertedOperation_3);
+                Assert.AreEqual(string.Empty, insertedOperation_3.BaseOperation.LuaName);
 
                 // no operation
-                insertedOperation_null = modesManager.InsertCopy(null) as Mode;
+                var insertedOperation_null = modesManager.InsertCopy(null) as Mode;
                 Assert.IsNull(insertedOperation_null);
 
                 // Вставка операции без базовой операции
@@ -155,20 +159,24 @@ namespace TechObject.Tests
 
                 // Замена предыдущей операции на базовую операцию 2
                 var replacedOperation_2 = modesManager.Replace(insertedOperation_no_base, copied_operation_2) as Mode;
-                Assert.IsNotNull(insertedOperation_1);
+                Assert.IsNotNull(replacedOperation_2);
                 Assert.AreNotSame(copied_operation_2, replacedOperation_2);
                 Assert.AreEqual(copied_operation_2.BaseOperation.LuaName, replacedOperation_2.BaseOperation.LuaName);
 
-                // Замена предыдущей операции на базовую операцию 1 (canceled)
-                var replacedOperation_null = modesManager.Replace(replacedOperation_2, copied_operation_1) as Mode;
-                Assert.IsNull(replacedOperation_null);
+                // Замена предыдущей операции на базовую операцию 1
+                var replacedOperation_1 = modesManager.Replace(replacedOperation_2, copied_operation_1) as Mode;
+                Assert.IsNotNull(replacedOperation_1);
+                Assert.AreNotSame(copied_operation_1, replacedOperation_1);
+                Assert.AreEqual(string.Empty, replacedOperation_1.BaseOperation.LuaName);
 
-                // Замена предыдущей операции на несуществующую базовую операцию 3 (canceled)
-                replacedOperation_null = modesManager.Replace(replacedOperation_2, copied_operation_3) as Mode;
-                Assert.IsNull(replacedOperation_null);
+                // Замена предыдущей операции на несуществующую базовую операцию 3
+                var replacedOperation_3 = modesManager.Replace(replacedOperation_1, copied_operation_3) as Mode;
+                Assert.IsNotNull(replacedOperation_3);
+                Assert.AreNotSame(copied_operation_3, replacedOperation_3);
+                Assert.AreEqual(string.Empty, replacedOperation_3.BaseOperation.LuaName);
 
                 // no operation
-                replacedOperation_null = modesManager.Replace(null, null) as Mode;
+                var replacedOperation_null = modesManager.Replace(null, null) as Mode;
                 Assert.IsNull(replacedOperation_null);
             });
         }

--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/State.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/State.Test.cs
@@ -156,12 +156,14 @@ namespace EasyEplanner.Tests
                 Assert.AreNotSame(copied_step_1, insertedStep_1);
                 Assert.AreEqual(copied_step_1.GetBaseStepLuaName(), insertedStep_1.GetBaseStepLuaName());
 
-                // Повторная вставка базового шага 1 (canceled)
-                var insertedStep_null = state.InsertCopy(copied_step_1) as Step;
-                Assert.IsNull(insertedStep_null);
+                // Повторная вставка базового шага 1
+                insertedStep_1 = state.InsertCopy(copied_step_1) as Step;
+                Assert.IsNotNull(insertedStep_1);
+                Assert.AreNotSame(copied_step_1, insertedStep_1);
+                Assert.AreEqual(string.Empty, insertedStep_1.GetBaseStepLuaName());
 
                 // no step
-                insertedStep_null = state.InsertCopy(null) as Step;
+                var insertedStep_null = state.InsertCopy(null) as Step;
                 Assert.IsNull(insertedStep_null);
 
                 // Вставка не базового шага
@@ -176,12 +178,14 @@ namespace EasyEplanner.Tests
                 Assert.AreNotSame(copied_step_2, replacedStep_2);
                 Assert.AreEqual(copied_step_2.GetBaseStepLuaName(), replacedStep_2.GetBaseStepLuaName());
 
-                // Замена предыдущего шага на уже имеющийся шаг 1 (canceled)
-                var replacedStep_null = state.Replace(replacedStep_2, copied_step_1) as Step;
-                Assert.IsNull(replacedStep_null);
+                // Замена предыдущего шага на уже имеющийся шаг 1
+                var replacedStep_1 = state.Replace(replacedStep_2, copied_step_1) as Step;
+                Assert.IsNotNull(replacedStep_1);
+                Assert.AreNotSame(copied_step_1, replacedStep_1);
+                Assert.AreEqual(string.Empty, replacedStep_1.GetBaseStepLuaName());
 
                 // no step
-                replacedStep_null = state.Replace(null, null) as Step;
+                var replacedStep_null = state.Replace(null, null) as Step;
                 Assert.IsNull(replacedStep_null);
             });
         }

--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/State.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/State.Test.cs
@@ -125,5 +125,65 @@ namespace EasyEplanner.Tests
                 Assert.IsNull(state.MoveDown(0));
             });
         }
+
+        [Test]
+        public void InsertCopyAndReplace()
+        {
+            var operation = new Mode("Операция", getN => 1, null,
+                new BaseOperation(
+                    "операция", "operation",
+                    new List<BaseParameter>() { },
+                    new Dictionary<string, List<BaseStep>>() 
+                    {
+                        { "RUN", new List<BaseStep>() { new BaseStep("", ""), new BaseStep("шаг_1", "step_1"), new BaseStep("шаг_2", "step_2") } },
+                    }
+                )
+            );
+
+            var state = new State(State.StateType.RUN, operation, true);
+
+            var copied_step_1 = new Step("шаг_1", getN => 1, state);
+            copied_step_1.SetNewValue("step_1", false);
+            var copied_step_2 = new Step("шаг_2", getN => 1, state);
+            copied_step_2.SetNewValue("step_2", false);
+            var copied_step_no_base = new Step("шаг", getN => 1, state);
+
+            Assert.Multiple(() =>
+            {
+                // Вставка базового шага 1
+                var insertedStep_1 = state.InsertCopy(copied_step_1) as Step;
+                Assert.IsNotNull(insertedStep_1);
+                Assert.AreNotSame(copied_step_1, insertedStep_1);
+                Assert.AreEqual(copied_step_1.GetBaseStepLuaName(), insertedStep_1.GetBaseStepLuaName());
+
+                // Повторная вставка базового шага 1 (canceled)
+                var insertedStep_null = state.InsertCopy(copied_step_1) as Step;
+                Assert.IsNull(insertedStep_null);
+
+                // no step
+                insertedStep_null = state.InsertCopy(null) as Step;
+                Assert.IsNull(insertedStep_null);
+
+                // Вставка не базового шага
+                var insertedStep_no_base = state.InsertCopy(copied_step_no_base) as Step;
+                Assert.IsNotNull(insertedStep_no_base);
+                Assert.AreNotSame(copied_step_no_base, insertedStep_no_base);
+                Assert.AreEqual(copied_step_no_base.GetBaseStepLuaName(), insertedStep_no_base.GetBaseStepLuaName());
+
+                // Замена не базового шага базовым шагом 2
+                var replacedStep_2 = state.Replace(insertedStep_no_base, copied_step_2) as Step;
+                Assert.IsNotNull(replacedStep_2);
+                Assert.AreNotSame(copied_step_2, replacedStep_2);
+                Assert.AreEqual(copied_step_2.GetBaseStepLuaName(), replacedStep_2.GetBaseStepLuaName());
+
+                // Замена предыдущего шага на уже имеющийся шаг 1 (canceled)
+                var replacedStep_null = state.Replace(replacedStep_2, copied_step_1) as Step;
+                Assert.IsNull(replacedStep_null);
+
+                // no step
+                replacedStep_null = state.Replace(null, null) as Step;
+                Assert.IsNull(replacedStep_null);
+            });
+        }
     }
 }

--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -157,7 +157,7 @@ namespace Editor
         /// <summary>
         /// Инициализация ComboBox редактора
         /// </summary>
-        private void InitComboBoxCellEditor(List<string> data)
+        private void InitComboBoxCellEditor(IEnumerable<string> data)
         {
             comboBoxCellEditor = new ComboBox();
             comboBoxCellEditor.Items.AddRange(data.ToArray());
@@ -1391,12 +1391,13 @@ namespace Editor
             IsCellEditing = true;
             ITreeViewItem item = editorTView.SelectedObject as ITreeViewItem;
 
+
             if (item == null ||
                 !item.IsEditable ||
                 item.EditablePart[e.Column.Index] != e.Column.Index ||
                 (e.Column.Index == 1 &&
                 item.ContainsBaseObject &&
-                item.BaseObjectsList.Count == 0))
+                !item.BaseObjectsList.Any()))
             {
                 IsCellEditing = false;
                 e.Cancel = true;

--- a/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
@@ -119,7 +119,7 @@ namespace TechObject
             clone.stepsMngr = new List<State>();
             for (int idx = 0; idx < stepsMngr.Count; idx++)
             {
-                clone.stepsMngr.Add(stepsMngr[idx].Clone());
+                clone.stepsMngr.Add(stepsMngr[idx].Clone(clone));
             }
 
             clone.operPar = operPar.Clone(clone);
@@ -545,7 +545,7 @@ namespace TechObject
             bool statesNotNull = selectedState != null && copiedState != null;
             if (statesNotNull)
             {
-                State newState = copiedState.Clone();
+                State newState = copiedState.Clone(this);
                 if (newState.Name != selectedState.Name)
                 {
                     newState.Name = selectedState.Name;

--- a/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
@@ -405,7 +405,7 @@ namespace TechObject
             if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
                 !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
                 !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
-                modes.Except(new List<Mode>() { targetOperation }).Any(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
+                modes.Except(new List<Mode>() { targetOperation }).ToList().Exists(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
                 return null;
 
             Mode newMode = copiedOperation.Clone(GetModeN, this, copiedOperation.Name);
@@ -422,7 +422,6 @@ namespace TechObject
             string modeTechObjName = Owner.NameEplan;
             int modeTechObjNumber = Owner.TechNumber;
             string copyObjTechObjName = copiedOperation.Owner.Owner.NameEplan;
-            int copyObjTechObjNumber = copiedOperation.Owner.Owner.TechNumber;
             if (modeTechObjName == copyObjTechObjName)
             {
                 newMode.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
@@ -463,7 +462,7 @@ namespace TechObject
             if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
                 !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
                 !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
-                modes.Any(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
+                modes.Exists(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
                 return null;
 
             Mode newOperation = copiedOperation.Clone(GetModeN, this);

--- a/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
@@ -401,47 +401,44 @@ namespace TechObject
             if (targetOperation is null || copiedOperation is null)
                 return null;
 
+            Mode newOperation = copiedOperation.Clone(GetModeN, this, copiedOperation.Name);
 
             if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
                 !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
                 !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
                 modes.Except(new List<Mode>() { targetOperation }).ToList().Exists(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
-                return null;
-
-            Mode newMode = copiedOperation.Clone(GetModeN, this, copiedOperation.Name);
-            if (!targetOperation.BaseObjectsList.Contains(copiedOperation.BaseOperation.Name))
             {
-                bool editBaseOperation = true;
-                newMode.SetNewValue(string.Empty, editBaseOperation);
+                // reset base object
+                newOperation.SetNewValue(string.Empty, true);
             }
 
             int index = modes.IndexOf(targetOperation);
             modes.Remove(targetOperation);
-            modes.Insert(index, newMode);
+            modes.Insert(index, newOperation);
 
             string modeTechObjName = Owner.NameEplan;
             int modeTechObjNumber = Owner.TechNumber;
             string copyObjTechObjName = copiedOperation.Owner.Owner.NameEplan;
             if (modeTechObjName == copyObjTechObjName)
             {
-                newMode.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
+                newOperation.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
             }
             else
             {
-                newMode.ModifyDevNames(new DevModifyOptions(Owner, copyObjTechObjName, Owner.TechNumber));
+                newOperation.ModifyDevNames(new DevModifyOptions(Owner, copyObjTechObjName, Owner.TechNumber));
             }
 
-            ChangeRestrictionModeOwner(newMode);
+            ChangeRestrictionModeOwner(newOperation);
             int newN = TechObjectManager.GetInstance()
                 .GetTechObjectN(Owner);
             int oldN = TechObjectManager.GetInstance()
                 .GetTechObjectN(copiedOperation.Owner.Owner);
-            newMode.ModifyRestrictObj(oldN, newN);
+            newOperation.ModifyRestrictObj(oldN, newN);
 
-            newMode.ChangeCrossRestriction(targetOperation);
+            newOperation.ChangeCrossRestriction(targetOperation);
 
-            newMode.AddParent(this);
-            return newMode;
+            newOperation.AddParent(this);
+            return newOperation;
         }
 
         override public bool IsInsertableCopy
@@ -459,14 +456,17 @@ namespace TechObject
             if (copiedOperation is null)
                 return null;
 
+            Mode newOperation = copiedOperation.Clone(GetModeN, this);
+
             if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
                 !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
                 !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
                 modes.Exists(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
-                return null;
+            {
+                // reset base object
+                newOperation.SetNewValue(string.Empty, true);    
+            }
 
-            Mode newOperation = copiedOperation.Clone(GetModeN, this);
-            
             modes.Add(newOperation);
 
             string techObjectName = copiedOperation.Owner.Owner.NameEplan;

--- a/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/ModesManager.cs
@@ -395,49 +395,54 @@ namespace TechObject
         override public ITreeViewItem Replace(object child,
             object copyObject)
         {
-            var mode = child as Mode;
-            var copyMode = copyObject as Mode;
-            bool objectsNotNull = mode != null && copyMode != null;
-            if (objectsNotNull)
+            var targetOperation = child as Mode;
+            var copiedOperation = copyObject as Mode;
+            
+            if (targetOperation is null || copiedOperation is null)
+                return null;
+
+
+            if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
+                !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
+                !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
+                modes.Except(new List<Mode>() { targetOperation }).Any(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
+                return null;
+
+            Mode newMode = copiedOperation.Clone(GetModeN, this, copiedOperation.Name);
+            if (!targetOperation.BaseObjectsList.Contains(copiedOperation.BaseOperation.Name))
             {
-                Mode newMode = copyMode.Clone(GetModeN, this, copyMode.Name);
-                if (!mode.BaseObjectsList.Contains(copyMode.BaseOperation.Name))
-                {
-                    bool editBaseOperation = true;
-                    newMode.SetNewValue(string.Empty, editBaseOperation);
-                }
-                
-                int index = modes.IndexOf(mode);
-                modes.Remove(mode);
-                modes.Insert(index, newMode);
-
-                string modeTechObjName = Owner.NameEplan;
-                int modeTechObjNumber = Owner.TechNumber;
-                string copyObjTechObjName = copyMode.Owner.Owner.NameEplan;
-                int copyObjTechObjNumber = copyMode.Owner.Owner.TechNumber;
-                if (modeTechObjName == copyObjTechObjName)
-                {
-                    newMode.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
-                }
-                else
-                {
-                    newMode.ModifyDevNames(new DevModifyOptions(Owner, copyObjTechObjName, Owner.TechNumber));
-                }
-
-                ChangeRestrictionModeOwner(newMode);
-                int newN = TechObjectManager.GetInstance()
-                    .GetTechObjectN(Owner);
-                int oldN = TechObjectManager.GetInstance()
-                    .GetTechObjectN(copyMode.Owner.Owner);
-                newMode.ModifyRestrictObj(oldN, newN);
-
-                newMode.ChangeCrossRestriction(mode);
-
-                newMode.AddParent(this);
-                return newMode;
+                bool editBaseOperation = true;
+                newMode.SetNewValue(string.Empty, editBaseOperation);
             }
 
-            return null;
+            int index = modes.IndexOf(targetOperation);
+            modes.Remove(targetOperation);
+            modes.Insert(index, newMode);
+
+            string modeTechObjName = Owner.NameEplan;
+            int modeTechObjNumber = Owner.TechNumber;
+            string copyObjTechObjName = copiedOperation.Owner.Owner.NameEplan;
+            int copyObjTechObjNumber = copiedOperation.Owner.Owner.TechNumber;
+            if (modeTechObjName == copyObjTechObjName)
+            {
+                newMode.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
+            }
+            else
+            {
+                newMode.ModifyDevNames(new DevModifyOptions(Owner, copyObjTechObjName, Owner.TechNumber));
+            }
+
+            ChangeRestrictionModeOwner(newMode);
+            int newN = TechObjectManager.GetInstance()
+                .GetTechObjectN(Owner);
+            int oldN = TechObjectManager.GetInstance()
+                .GetTechObjectN(copiedOperation.Owner.Owner);
+            newMode.ModifyRestrictObj(oldN, newN);
+
+            newMode.ChangeCrossRestriction(targetOperation);
+
+            newMode.AddParent(this);
+            return newMode;
         }
 
         override public bool IsInsertableCopy
@@ -450,31 +455,36 @@ namespace TechObject
 
         override public ITreeViewItem InsertCopy(object obj)
         {
-            var objMode = obj as Mode;
-            if (objMode != null)
+            var copiedOperation = obj as Mode;
+
+            if (copiedOperation is null)
+                return null;
+
+            if (owner.BaseTechObject.BaseOperationsList.Count > 0 &&
+                !Owner.BaseTechObject.BaseOperationsList.Contains(copiedOperation.BaseOperation.Name) ||
+                !string.IsNullOrEmpty(copiedOperation.BaseOperation?.LuaName) &&
+                modes.Any(o => o.BaseOperation.LuaName == copiedOperation.BaseOperation.LuaName))
+                return null;
+
+            Mode newOperation = copiedOperation.Clone(GetModeN, this);
+            
+            modes.Add(newOperation);
+
+            string techObjectName = copiedOperation.Owner.Owner.NameEplan;
+            if (owner.NameEplan == techObjectName)
             {
-                Mode newMode = objMode.Clone(GetModeN, this);
-                modes.Add(newMode);
-
-                string objModeTechObjectName = objMode.Owner.Owner.NameEplan;
-                int objMobeTechObjectNumber = objMode.Owner.Owner.TechNumber;
-                if (owner.NameEplan == objModeTechObjectName)
-                {
-                    newMode.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
-                }
-                else
-                {
-                    newMode.ModifyDevNames(new DevModifyOptions(Owner, objModeTechObjectName, Owner.TechNumber));
-                }
-
-                ChangeRestrictionModeOwner(newMode);
-                newMode.ChangeCrossRestriction();
-
-                newMode.AddParent(this);
-                return newMode;
+                newOperation.ModifyDevNames(new DevModifyOptions(Owner, Owner.NameEplan, -1));
+            }
+            else
+            {
+                newOperation.ModifyDevNames(new DevModifyOptions(Owner, techObjectName, Owner.TechNumber));
             }
 
-            return null;
+            ChangeRestrictionModeOwner(newOperation);
+            newOperation.ChangeCrossRestriction();
+
+            newOperation.AddParent(this);
+            return newOperation;
         }
 
         override public bool IsInsertable

--- a/src/TechObject/ObjectsTree/UniversalObject/State.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/State.cs
@@ -384,51 +384,62 @@ namespace TechObject
 
         override public ITreeViewItem Replace(object child, object copyObject)
         {
-            var step = child as Step;
-            var copy = copyObject as Step;
-            bool objectsNotNull = step != null && copy != null;
-            if (objectsNotNull)
+            var targetStep = child as Step;
+            var copiedStep = copyObject as Step;
+
+            if (targetStep is null || copiedStep is null)
+                return null;
+            
+            if (Owner.BaseOperation.GetStateStepsNames(Type).Count > 0 &&
+                !Owner.BaseOperation.GetStateStepsNames(Type).Contains(copiedStep.GetBaseStepName()) ||
+                !string.IsNullOrEmpty(copiedStep.GetBaseStepLuaName()) &&
+                steps.Except(new List<Step>() { targetStep }).Any(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
+                return null;
+
+            Step newStep = copiedStep.Clone(GetStepN);
+            if (!targetStep.BaseObjectsList.Contains(newStep.GetBaseStepName()))
             {
-                Step newStep = copy.Clone(GetStepN);
-                if (!step.BaseObjectsList.Contains(newStep.GetBaseStepName()))
-                {
-                    bool editBaseStep = true;
-                    newStep.SetNewValue(string.Empty, editBaseStep);
-                }
-
-                int index = steps.IndexOf(step);
-                steps.Remove(step);
-                steps.Insert(index, newStep);
-                bool isModeStep = index == 0;
-                if (isModeStep)
-                {
-                    modeStep = newStep;
-                }
-
-                newStep.Owner = this;
-               
-                index = steps.IndexOf(newStep);
-
-                newStep.AddParent(this);
-                return newStep;
+                bool editBaseStep = true;
+                newStep.SetNewValue(string.Empty, editBaseStep);
             }
 
-            return null;
+            int index = steps.IndexOf(targetStep);
+            steps.Remove(targetStep);
+            steps.Insert(index, newStep);
+            bool isModeStep = index == 0;
+            if (isModeStep)
+            {
+                modeStep = newStep;
+            }
+
+            newStep.Owner = this;
+            
+            index = steps.IndexOf(newStep);
+
+            newStep.AddParent(this);
+            return newStep;
         }
 
         public override ITreeViewItem InsertCopy(object copyObject)
         {
-            var copy = copyObject as Step;
-            if(copy != null)
-            {
-                var newStep = copy.Clone(GetStepN);
-                steps.Add(newStep);
-                newStep.AddParent(this);
-                newStep.Owner = this;
-                return newStep;
-            }
+            var copiedStep = copyObject as Step;
 
-            return null;
+            if (copiedStep is null)
+                return null;
+           
+            if (Owner.BaseOperation.GetStateStepsNames(Type).Count > 0 && 
+                !Owner.BaseOperation.GetStateStepsNames(Type).Contains(copiedStep.GetBaseStepName()) ||
+                !string.IsNullOrEmpty(copiedStep.GetBaseStepLuaName()) &&
+                steps.Any(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
+                return null;
+
+            var newStep = copiedStep.Clone(GetStepN);
+
+            steps.Add(newStep);
+            newStep.AddParent(this);
+            newStep.Owner = this;
+            
+            return newStep;
         }
 
         override public bool IsCopyable

--- a/src/TechObject/ObjectsTree/UniversalObject/State.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/State.cs
@@ -393,7 +393,7 @@ namespace TechObject
             if (Owner.BaseOperation.GetStateStepsNames(Type).Count > 0 &&
                 !Owner.BaseOperation.GetStateStepsNames(Type).Contains(copiedStep.GetBaseStepName()) ||
                 !string.IsNullOrEmpty(copiedStep.GetBaseStepLuaName()) &&
-                steps.Except(new List<Step>() { targetStep }).Any(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
+                steps.Except(new List<Step>() { targetStep }).ToList().Exists(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
                 return null;
 
             Step newStep = copiedStep.Clone(GetStepN);
@@ -430,7 +430,7 @@ namespace TechObject
             if (Owner.BaseOperation.GetStateStepsNames(Type).Count > 0 && 
                 !Owner.BaseOperation.GetStateStepsNames(Type).Contains(copiedStep.GetBaseStepName()) ||
                 !string.IsNullOrEmpty(copiedStep.GetBaseStepLuaName()) &&
-                steps.Any(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
+                steps.Exists(s => s.GetBaseStepLuaName() == copiedStep.GetBaseStepLuaName()))
                 return null;
 
             var newStep = copiedStep.Clone(GetStepN);

--- a/src/TechObject/ObjectsTree/UniversalObject/Step.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Step.cs
@@ -413,7 +413,7 @@ namespace TechObject
             items.Add(toStateByConditionAction);
         }
 
-        public Step Clone(GetN getN, string name = "")
+        public Step Clone(State newOwner, GetN getN, string name = "")
         {
             Step clone = (Step)MemberwiseClone();
             clone.getN = getN;
@@ -423,6 +423,7 @@ namespace TechObject
                 clone.name = name.Substring(3);
             }
 
+            clone.Owner = newOwner;
             clone.actions = new List<IAction>();
             foreach (IAction action in actions)
             {


### PR DESCRIPTION
Fixes #1429.

```ChangeLog
Исправлен функционал копирования/вставки(замены) базовых операций и шагов: при вставке/замене базовая операция/шаг сбрасывается, если такая же уже есть или, если ее не может быть в данном объете;
```