### PR TITLE
BaseObjectList exclude base operation and step if same exists

### DIFF
--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Mode.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Mode.Test.cs
@@ -208,5 +208,31 @@ namespace EasyEplannerTests.TechObjectTest.ObjectsTreeTest.UniversalObjectTest
             mode.UpdateOnGenericTechObject(null);
             Assert.IsTrue(stateUpdateMethodCalled);
         }
+
+        [Test]
+        public void GetBaseObjectList()
+        {
+
+            var baseTechObject = new BaseTechObject()
+            {
+                Name = "base_tech_object",
+            };
+            baseTechObject.AddBaseOperation("operation_1", "операция 1", 0);
+            baseTechObject.AddBaseOperation("operation_2", "операция 2", 0);
+            baseTechObject.AddBaseOperation("operation_3", "операция 3", 0);
+
+            var techObject = new TechObject.TechObject("", getN => 1, 1, 1, "", -1, "", "", baseTechObject);
+            var modesManager = new ModesManager(techObject);
+
+            var mode = modesManager.AddMode("", "");
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(new List<string>() { "", "операция 1", "операция 2", "операция 3" }, mode.BaseObjectsList);
+                
+                modesManager.AddMode("операция 2", "operation_2");
+                CollectionAssert.AreEqual(new List<string>() { "", "операция 1", "операция 3" }, mode.BaseObjectsList);
+            });
+        }
     }
 }

--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Step.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/UniversalObject.Test/Step.Test.cs
@@ -766,5 +766,27 @@ namespace EasyEplanner.Tests
                 Assert.AreEqual("1", step.MaxDurationParam);
             });
         }
+
+        [Test]
+        public void GetBaseObjectList()
+        {
+            var mode = new Mode("", getN => 1, null, new BaseOperation("", "", new List<BaseParameter>() { },
+                new Dictionary<string, List<BaseStep>>() 
+                {
+                    { "RUN", new List<BaseStep>() { new BaseStep("", ""), new BaseStep("шаг 1", "step_1"), new BaseStep("шаг 2", "step_2") } }
+                }));
+            var state = new State(State.StateType.RUN, mode);
+            var step = state.AddStep("", "");
+
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(new List<string>() { "", "шаг 1", "шаг 2" }, step.BaseObjectsList);
+                
+                state.AddStep("шаг 1", "step_1");
+                CollectionAssert.AreEqual(new List<string>() { "", "шаг 2" }, step.BaseObjectsList);
+            });
+
+        }
     }
 }

--- a/src/Editor/ITreeViewItem.cs
+++ b/src/Editor/ITreeViewItem.cs
@@ -267,7 +267,7 @@ namespace Editor
         /// <summary>
         /// Список базовых объектов/операций/шагов объекта.
         /// </summary>
-        List<string> BaseObjectsList { get; }
+        IEnumerable<string> BaseObjectsList { get; }
 
         /// <summary>
         /// Отключено или нет свойство

--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -1397,7 +1397,7 @@ namespace Editor
                 item.EditablePart[e.Column.Index] != e.Column.Index ||
                 (e.Column.Index == 1 &&
                 item.ContainsBaseObject &&
-                item.BaseObjectsList.Count() == 0))
+                !item.BaseObjectsList.Any()))
             {
                 IsCellEditing = false;
                 e.Cancel = true;

--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -157,7 +157,7 @@ namespace Editor
         /// <summary>
         /// Инициализация ComboBox редактора
         /// </summary>
-        private void InitComboBoxCellEditor(List<string> data)
+        private void InitComboBoxCellEditor(IEnumerable<string> data)
         {
             comboBoxCellEditor = new ComboBox();
             comboBoxCellEditor.Items.AddRange(data.ToArray());
@@ -1391,12 +1391,13 @@ namespace Editor
             IsCellEditing = true;
             ITreeViewItem item = editorTView.SelectedObject as ITreeViewItem;
 
+
             if (item == null ||
                 !item.IsEditable ||
                 item.EditablePart[e.Column.Index] != e.Column.Index ||
                 (e.Column.Index == 1 &&
                 item.ContainsBaseObject &&
-                item.BaseObjectsList.Count == 0))
+                item.BaseObjectsList.Count() == 0))
             {
                 IsCellEditing = false;
                 e.Cancel = true;

--- a/src/Editor/ObjectProperty.cs
+++ b/src/Editor/ObjectProperty.cs
@@ -470,7 +470,7 @@ namespace Editor
             }
         }
 
-        public virtual List<string> BaseObjectsList
+        public virtual IEnumerable<string> BaseObjectsList
         {
             get
             {

--- a/src/Editor/TreeViewItem.cs
+++ b/src/Editor/TreeViewItem.cs
@@ -377,7 +377,7 @@ namespace Editor
             }
         }
 
-        public virtual List<string> BaseObjectsList
+        public virtual IEnumerable<string> BaseObjectsList
         {
             get
             {

--- a/src/TechObject/Base/Properties/ActiveBoolParameter.cs
+++ b/src/TechObject/Base/Properties/ActiveBoolParameter.cs
@@ -89,7 +89,7 @@ namespace TechObject
             }
         }
 
-        public override List<string> BaseObjectsList
+        public override IEnumerable<string> BaseObjectsList
         {
             get
             {

--- a/src/TechObject/Base/Properties/ComboBoxParameter.cs
+++ b/src/TechObject/Base/Properties/ComboBoxParameter.cs
@@ -119,7 +119,7 @@ namespace TechObject
             }
         }
 
-        public override List<string> BaseObjectsList
+        public override IEnumerable<string> BaseObjectsList
         {
             get
             {

--- a/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
@@ -638,13 +638,12 @@ namespace TechObject
             return devToDraw;
         }
 
-        public override List<string> BaseObjectsList
+        public override IEnumerable<string> BaseObjectsList
         {
             get => Owner.Owner.BaseTechObject.BaseOperationsList
                 .Except(from operation in Owner.Modes
                         where operation.BaseOperation.Name != string.Empty
-                        select operation.BaseOperation.Name)
-                .ToList();
+                        select operation.BaseOperation.Name);
         }
 
         public override bool ContainsBaseObject

--- a/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Mode.cs
@@ -640,14 +640,11 @@ namespace TechObject
 
         public override List<string> BaseObjectsList
         {
-            get
-            {
-                ModesManager modesManager = Owner;
-                TechObject techObject = modesManager.Owner;
-                BaseTechObject baseTechObject = techObject.BaseTechObject;
-                List<string> baseModesList = baseTechObject.BaseOperationsList;
-                return baseModesList;
-            }
+            get => Owner.Owner.BaseTechObject.BaseOperationsList
+                .Except(from operation in Owner.Modes
+                        where operation.BaseOperation.Name != string.Empty
+                        select operation.BaseOperation.Name)
+                .ToList();
         }
 
         public override bool ContainsBaseObject

--- a/src/TechObject/ObjectsTree/UniversalObject/Step.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Step.cs
@@ -892,14 +892,12 @@ namespace TechObject
 
         public override List<string> BaseObjectsList
         {
-            get
-            {
-                State state = Owner;
-                Mode mode = state.Owner;
-                List<string> stepsNames = mode.BaseOperation
-                    .GetStateStepsNames(state.Type);
-                return stepsNames;
-            }
+            get => Owner.Owner.BaseOperation
+                .GetStateStepsNames(Owner.Type)
+                .Except(from step in Owner.Steps
+                        where step.GetBaseStepName() != string.Empty
+                        select step.GetBaseStepName())
+                .ToList();
         }
 
         public override bool ContainsBaseObject

--- a/src/TechObject/ObjectsTree/UniversalObject/Step.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Step.cs
@@ -890,14 +890,14 @@ namespace TechObject
             return devToDraw;
         }
 
-        public override List<string> BaseObjectsList
+        public override IEnumerable<string> BaseObjectsList
         {
             get => Owner.Owner.BaseOperation
                 .GetStateStepsNames(Owner.Type)
                 .Except(from step in Owner.Steps
                         where step.GetBaseStepName() != string.Empty
                         select step.GetBaseStepName())
-                .ToList();
+                ;
         }
 
         public override bool ContainsBaseObject


### PR DESCRIPTION
Fixes #1430.

```ChangeLog
Теперь при выборе базовой операции или шага в выпадающем списке исключаются уже добавленные базовые операции;
```