### PR TITLE
Set R_EXTRA_OFFSET for IO-Link valves binded to WAGO IO-Link master

### DIFF
--- a/EasyEplanner.Tests/Configuration.Test/DeviceBindingReader.Test.cs
+++ b/EasyEplanner.Tests/Configuration.Test/DeviceBindingReader.Test.cs
@@ -179,7 +179,7 @@ namespace EasyEplannerTests.ConfigurationTest
             {
                 DeviceBindingReader.CheckAndSetExtraOffset(module, valve, 1);
                 Assert.IsTrue(valve.RuntimeParameters.TryGetValue(IODevice.RuntimeParameter.R_EXTRA_OFFSET, out var extraOffset));
-                Assert.AreEqual(null, extraOffset);
+                Assert.AreEqual(0, extraOffset);
 
                 DeviceBindingReader.CheckAndSetExtraOffset(module, valve, 3);
                 valve.RuntimeParameters.TryGetValue(IODevice.RuntimeParameter.R_EXTRA_OFFSET, out extraOffset);

--- a/EasyEplanner.Tests/Configuration.Test/DeviceBindingReader.Test.cs
+++ b/EasyEplanner.Tests/Configuration.Test/DeviceBindingReader.Test.cs
@@ -162,5 +162,29 @@ namespace EasyEplannerTests.ConfigurationTest
                 DeviceBindingReader.CheckBindAllowedSubTypesToDOModule(device, moduleMock.Object, "") == string.Empty);
         }
 
+
+        [Test]
+        public void CheckAndSetExtraOffset()
+        {
+            var ioModuleInfo = IOModuleInfo.Stub;
+            ioModuleInfo.Number = 657;
+
+            var module = Mock.Of<IIOModule>(m => 
+                m.Info == ioModuleInfo);
+
+            var valve = new V("V1", "-V1", "", 1, "", -1, "");
+            valve.SetSubType(DeviceSubType.V_IOLINK_MIXPROOF.ToString());
+
+            Assert.Multiple(() =>
+            {
+                DeviceBindingReader.CheckAndSetExtraOffset(module, valve, 1);
+                Assert.IsTrue(valve.RuntimeParameters.TryGetValue(IODevice.RuntimeParameter.R_EXTRA_OFFSET, out var extraOffset));
+                Assert.AreEqual(null, extraOffset);
+
+                DeviceBindingReader.CheckAndSetExtraOffset(module, valve, 3);
+                valve.RuntimeParameters.TryGetValue(IODevice.RuntimeParameter.R_EXTRA_OFFSET, out extraOffset);
+                Assert.AreEqual(-2, extraOffset);
+            });
+        }
     }
 }

--- a/EasyEplanner.Tests/EplanDevice.Test/IODevice.Test/V.Test.cs
+++ b/EasyEplanner.Tests/EplanDevice.Test/IODevice.Test/V.Test.cs
@@ -747,6 +747,11 @@ namespace Tests.EplanDevices
                 IODevice.RuntimeParameter.R_ID_LOWER_SEAT,
             };
 
+            var V_IOL_EXTRA_OFFSET_RT = new string[]
+            {
+                IODevice.RuntimeParameter.R_EXTRA_OFFSET,
+            };
+
             return new object[]
             {
                 new object[]
@@ -793,7 +798,7 @@ namespace Tests.EplanDevices
                 },
                 new object[]
                 {
-                    new string[0],
+                    V_IOL_EXTRA_OFFSET_RT,
                     V_IOLINK_MIXPROOF,
                     GetRandomVDevice()
                 },
@@ -817,7 +822,7 @@ namespace Tests.EplanDevices
                 },
                 new object[]
                 {
-                    new string[0],
+                    V_IOL_EXTRA_OFFSET_RT,
                     V_IOLINK_DO1_DI2,
                     GetRandomVDevice()
                 },

--- a/src/Configuration/DeviceBindingReader.cs
+++ b/src/Configuration/DeviceBindingReader.cs
@@ -601,14 +601,14 @@ namespace EasyEPlanner
         /// <param name="module">Модуль</param>
         /// <param name="device">Устройство</param>
         /// <param name="logicalPort">Логический номер клеммы (сигнальной)</param>
-        public void CheckAndSetExtraOffset(IIOModule module, IODevice device, int logicalPort)
+        public static void CheckAndSetExtraOffset(IIOModule module, IODevice device, int logicalPort)
         {
             if (module.Info.Number != 657 || // 750-657 - IO-Link Master
                 !device.RuntimeParameters.ContainsKey(IODevice.RuntimeParameter.R_EXTRA_OFFSET)) 
                 return;
 
-            if (logicalPort > 0)
-                device.RuntimeParameters[IODevice.RuntimeParameter.R_EXTRA_OFFSET] = -logicalPort;
+            if (logicalPort - 1 > 0)
+                device.RuntimeParameters[IODevice.RuntimeParameter.R_EXTRA_OFFSET] = -(logicalPort - 1);
         }
 
         /// <summary>

--- a/src/Configuration/DeviceBindingReader.cs
+++ b/src/Configuration/DeviceBindingReader.cs
@@ -607,8 +607,7 @@ namespace EasyEPlanner
                 !device.RuntimeParameters.ContainsKey(IODevice.RuntimeParameter.R_EXTRA_OFFSET)) 
                 return;
 
-            if (logicalPort - 1 > 0)
-                device.RuntimeParameters[IODevice.RuntimeParameter.R_EXTRA_OFFSET] = -(logicalPort - 1);
+            device.RuntimeParameters[IODevice.RuntimeParameter.R_EXTRA_OFFSET] = -(logicalPort - 1);
         }
 
         /// <summary>

--- a/src/Configuration/DeviceBindingReader.cs
+++ b/src/Configuration/DeviceBindingReader.cs
@@ -558,6 +558,8 @@ namespace EasyEPlanner
                         out error, module.PhysicalNumber, logicalPort,
                         moduleOffset, channelName);
 
+                CheckAndSetExtraOffset(module, device, logicalPort);
+
                 if (error != "")
                 {
                     error = string.Format("\"{0}:{1}\" : {2}",
@@ -590,6 +592,23 @@ namespace EasyEPlanner
                 Logs.AddMessage($"К модулю {module.Name} узла {node.Name} привязано несколько устройств " +
                     $"с одинаковым AS ({group.Key}): {string.Join(", ", group.Select(dev => dev.EplanName))}");
             }
+        }
+
+
+        /// <summary>
+        /// Проверка и установка доп.смещения привязки клапанов для IO-Link мастера
+        /// </summary>
+        /// <param name="module">Модуль</param>
+        /// <param name="device">Устройство</param>
+        /// <param name="logicalPort">Логический номер клеммы (сигнальной)</param>
+        public void CheckAndSetExtraOffset(IIOModule module, IODevice device, int logicalPort)
+        {
+            if (module.Info.Number != 657 || // 750-657 - IO-Link Master
+                !device.RuntimeParameters.ContainsKey(IODevice.RuntimeParameter.R_EXTRA_OFFSET)) 
+                return;
+
+            if (logicalPort > 0)
+                device.RuntimeParameters[IODevice.RuntimeParameter.R_EXTRA_OFFSET] = -logicalPort;
         }
 
         /// <summary>

--- a/src/Device/IODevices/V.cs
+++ b/src/Device/IODevices/V.cs
@@ -146,6 +146,8 @@ namespace EplanDevice
                     AO.Add(new IOChannel("AO", -1, -1, -1, ""));
                     AI.Add(new IOChannel("AI", -1, -1, -1, ""));
 
+                    rtParameters.Add(RuntimeParameter.R_EXTRA_OFFSET, null);
+
                     SetIOLinkSizes(ArticleName);
                     break;
 
@@ -186,6 +188,8 @@ namespace EplanDevice
 
                     parameters.Add(Parameter.P_ON_TIME, null);
                     parameters.Add(Parameter.P_FB, 1);
+
+                    rtParameters.Add(RuntimeParameter.R_EXTRA_OFFSET, null);
 
                     SetIOLinkSizes(ArticleName);
                     break;

--- a/src/Device/RuntimeParameter.cs
+++ b/src/Device/RuntimeParameter.cs
@@ -43,7 +43,12 @@
             /// </summary>
             public const string R_ID_LOWER_SEAT = "R_ID_LOWER_SEAT";
 
-
+            /// <summary>
+            /// Смещение адресного пространства для клапанов 
+            /// <see cref="DeviceSubType.V_IOLINK_MIXPROOF"/>, <see cref="DeviceSubType.V_IOLINK_DO1_DI2"/>
+            /// привязанных к модулю WAGO.750-657
+            /// </summary>
+            public const string R_EXTRA_OFFSET = nameof(R_EXTRA_OFFSET);
         }
     }
 }


### PR DESCRIPTION
Fixes #1446.

```ChangeLog
Добавлен новый рабочий параметр R_EXTRA_OFFSET и его автоматическая установка при привязке к WAGO IO-Link мастеру;
```