### PR TITLE
change "LUA" to "Lua" in documentation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,7 +31,7 @@ Examples for EPLAN Electric P8 automation in the C# programming language can be 
 
 The EasyEPLANner is being developed as an Add-In to EPLAN 2.9 version. The add-in is being used for EPLAN projects and helps you to reduce the work of an Automation engineer and a Software engineer as well.
 
-Software engineer creates code in Lua programming language for the project. EasyEPLANner helps you to describe technological objects (Tank, Boiler, etc.), operations of these objects, steps of operations, restrictions for operations, and many other properties. Eventually, EasyEPLANner generates LUA files that are going to be uploaded to a controller. We support controllers from the following manufacturers:
+Software engineer creates code in Lua programming language for the project. EasyEPLANner helps you to describe technological objects (Tank, Boiler, etc.), operations of these objects, steps of operations, restrictions for operations, and many other properties. Eventually, EasyEPLANner generates Lua files that are going to be uploaded to a controller. We support controllers from the following manufacturers:
 
 1. [Phoenix Contact - PLCNext](https://github.com/plcnext);
 2. [WAGO - PFC200](https://github.com/WAGO).


### PR DESCRIPTION
Closes #1453

Исправлено написание названия языка программирования с "LUA" на "Lua" в документации. Название языка должно писаться с заглавной буквы только в начале.
