### PR TITLE
[Interproject exchange] Disable defined PAC settings if model not loaded

### DIFF
--- a/EasyEplanner.Tests/InterprojectExchange.Test/Models.Test/ProjectModelTest.cs
+++ b/EasyEplanner.Tests/InterprojectExchange.Test/Models.Test/ProjectModelTest.cs
@@ -21,5 +21,29 @@ namespace EasyEplannerEasyEplannerTests.InterprojectExchangeTest
 
             Assert.IsTrue(model.Loaded);
         }
+
+        public void AddPlcData()
+        {
+            var model = new AdvancedProjectModel
+            {
+                Loaded = true
+            };
+
+            model.AddPLCData(true, 1, 1, 1, true, 1, "pac_name");
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(model.PacInfo.ModelLoaded);
+                Assert.IsTrue(model.PacInfo.EmulationEnabled);
+                Assert.IsTrue(model.PacInfo.GateEnabled);
+
+                Assert.AreEqual(1, model.PacInfo.CycleTime);
+                Assert.AreEqual(1, model.PacInfo.TimeOut);
+                Assert.AreEqual(1, model.PacInfo.Port);
+                Assert.AreEqual(1, model.PacInfo.Station);
+
+                Assert.AreEqual("pac_name", model.ProjectName);
+            });
+        }
     }
 }

--- a/EasyEplanner.Tests/InterprojectExchange.Test/Models.Test/ProjectModelTest.cs
+++ b/EasyEplanner.Tests/InterprojectExchange.Test/Models.Test/ProjectModelTest.cs
@@ -22,6 +22,7 @@ namespace EasyEplannerEasyEplannerTests.InterprojectExchangeTest
             Assert.IsTrue(model.Loaded);
         }
 
+        [Test]
         public void AddPlcData()
         {
             var model = new AdvancedProjectModel
@@ -29,7 +30,14 @@ namespace EasyEplannerEasyEplannerTests.InterprojectExchangeTest
                 Loaded = true
             };
 
+            var currentModel = new CurrentProjectModel
+            {
+                Loaded = true
+            };
+
             model.AddPLCData(true, 1, 1, 1, true, 1, "pac_name");
+            currentModel.AddPLCData(true, 1, 1, 1, true, 1, "pac_name");
+            currentModel.SelectedAdvancedProject = "pac_name";
 
             Assert.Multiple(() =>
             {
@@ -37,12 +45,22 @@ namespace EasyEplannerEasyEplannerTests.InterprojectExchangeTest
                 Assert.IsTrue(model.PacInfo.EmulationEnabled);
                 Assert.IsTrue(model.PacInfo.GateEnabled);
 
+                Assert.IsTrue(currentModel.PacInfo.ModelLoaded);
+                Assert.IsTrue(currentModel.PacInfo.EmulationEnabled);
+                Assert.IsTrue(currentModel.PacInfo.GateEnabled);
+
                 Assert.AreEqual(1, model.PacInfo.CycleTime);
                 Assert.AreEqual(1, model.PacInfo.TimeOut);
                 Assert.AreEqual(1, model.PacInfo.Port);
                 Assert.AreEqual(1, model.PacInfo.Station);
 
+                Assert.AreEqual(1, currentModel.PacInfo.CycleTime);
+                Assert.AreEqual(1, currentModel.PacInfo.TimeOut);
+                Assert.AreEqual(1, currentModel.PacInfo.Port);
+                Assert.AreEqual(1, currentModel.PacInfo.Station);
+
                 Assert.AreEqual("pac_name", model.ProjectName);
+                Assert.AreEqual("pac_name", currentModel.ProjectName);
             });
         }
     }

--- a/EasyEplanner.Tests/InterprojectExchange.Test/PacInfo.Test.cs
+++ b/EasyEplanner.Tests/InterprojectExchange.Test/PacInfo.Test.cs
@@ -1,0 +1,37 @@
+﻿using InterprojectExchange;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EasyEplannerTests.InterprojectExchangeTest
+{
+    public class PacInfoTest
+    {
+        [Test]
+        public void CloneTest()
+        {
+            var pacInfo = new PacInfo()
+            {
+                ModelLoaded = true,
+                IP = "10.0.0.10",
+            };
+
+            var pacInfoClone = pacInfo.Clone();
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreNotSame(pacInfoClone, pacInfo);
+                Assert.AreEqual(pacInfo.ModelLoaded, pacInfoClone.ModelLoaded);
+                Assert.AreEqual(pacInfo.Port, pacInfoClone.Port);
+                Assert.AreEqual(pacInfo.IP, pacInfoClone.IP);
+                Assert.AreEqual(pacInfo.CycleTime, pacInfoClone.CycleTime);
+                Assert.AreEqual(pacInfo.Station, pacInfoClone.Station);
+                Assert.AreEqual(pacInfo.GateEnabled, pacInfoClone.GateEnabled);
+                Assert.AreEqual(pacInfo.EmulationEnabled, pacInfoClone.EmulationEnabled);
+            });
+        }
+    }
+}

--- a/src/InterprojectExchange/Forms/PACSettingsForm.cs
+++ b/src/InterprojectExchange/Forms/PACSettingsForm.cs
@@ -239,6 +239,12 @@ namespace InterprojectExchange
                     !signalsSendingToMainEmpty[projectName];
             }
 
+            // Настройки проекта, отключаемые для изменения, если модель не загружена
+            projNameTextBox.Enabled = pacInfo.ModelLoaded;
+            ipAddressTextBox.Enabled = pacInfo.ModelLoaded;
+            portTextBox.Enabled = pacInfo.ModelLoaded;
+            stationNumberTextBox.Enabled = pacInfo.ModelLoaded;
+
             projNameTextBox.Text = projectName;
             ipAddressTextBox.Text = pacInfo.IP;
             emulatorIPTextBox.Text = pacInfo.IPEmulator;

--- a/src/InterprojectExchange/Forms/PACSettingsForm.cs
+++ b/src/InterprojectExchange/Forms/PACSettingsForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -223,6 +224,7 @@ namespace InterprojectExchange
         /// Загрузка данных проекта в поля
         /// </summary>
         /// <param name="projectName">Имя проекта</param>
+        [ExcludeFromCodeCoverage]
         private void LoadProjectDataToFields(string projectName)
         {
             PacInfo pacInfo;

--- a/src/InterprojectExchange/Models/advancedProjectModel.cs
+++ b/src/InterprojectExchange/Models/advancedProjectModel.cs
@@ -120,6 +120,7 @@ namespace InterprojectExchange
             PacInfo.Port = port;
             PacInfo.GateEnabled = gateEnabled;
             PacInfo.Station = station;
+            PacInfo.ModelLoaded = Loaded;
         }
 
         /// <summary>

--- a/src/InterprojectExchange/Models/currentProjectModel.cs
+++ b/src/InterprojectExchange/Models/currentProjectModel.cs
@@ -140,6 +140,7 @@ namespace InterprojectExchange
             pacDTOs[pacName].Port = port;
             pacDTOs[pacName].GateEnabled = gateEnabled;
             pacDTOs[pacName].Station = station;
+            pacDTOs[pacName].ModelLoaded = Loaded;
         }
 
         /// <summary>

--- a/src/InterprojectExchange/PacInfo.cs
+++ b/src/InterprojectExchange/PacInfo.cs
@@ -23,18 +23,18 @@
         /// <returns></returns>
         public PacInfo Clone()
         {
-            var cloned = new PacInfo();
-
-            cloned.IP = IP;
-            cloned.IPEmulator = IPEmulator;
-            cloned.EmulationEnabled = EmulationEnabled;
-            cloned.CycleTime = CycleTime;
-            cloned.TimeOut = TimeOut;
-            cloned.Port = Port;
-            cloned.GateEnabled = GateEnabled;
-            cloned.Station = Station;
-
-            return cloned;
+            return new PacInfo
+            {
+                IP = IP,
+                IPEmulator = IPEmulator,
+                EmulationEnabled = EmulationEnabled,
+                CycleTime = CycleTime,
+                TimeOut = TimeOut,
+                Port = Port,
+                GateEnabled = GateEnabled,
+                Station = Station,
+                ModelLoaded = ModelLoaded
+            };
         }
 
         /// <summary>
@@ -76,5 +76,10 @@
         /// Номер Modbus-станции
         /// </summary>
         public int Station { get; set; }
+
+        /// <summary>
+        /// Модель загружена
+        /// </summary>
+        public bool ModelLoaded { get; set; } = false;
     }
 }


### PR DESCRIPTION
Fixes #1506.

```ChangeLog
Если в межконтроллерном обмене связуемый проект отсутсвует, то теперь нельзя изменить некоторые настройки PAC;
```