### PR TITLE
[Editor] Enables cut/copy/paste shortcuts in search box

### DIFF
--- a/src/Editor/NewEditorControl.Designer.cs
+++ b/src/Editor/NewEditorControl.Designer.cs
@@ -948,11 +948,13 @@ namespace Editor
             this.textBox_search.MaximumSize = new System.Drawing.Size(110, 0);
             this.textBox_search.MinimumSize = new System.Drawing.Size(110, 0);
             this.textBox_search.Name = "textBox_search";
+            this.textBox_search.ShortcutsEnabled = false;
             this.textBox_search.Size = new System.Drawing.Size(110, 13);
             this.textBox_search.TabIndex = 0;
             this.textBox_search.Text = "Поиск...";
             this.textBox_search.TextChanged += new System.EventHandler(this.textBox_search_TextChanged);
             this.textBox_search.GotFocus += new System.EventHandler(this.textBox_search_Enter);
+            this.textBox_search.KeyUp += new System.Windows.Forms.KeyEventHandler(this.TextBox_Commands_KeyUp);
             this.textBox_search.LostFocus += new System.EventHandler(this.textBox_search_Leave);
             // 
             // searchButtonToolStrip

--- a/src/Editor/NewEditorControl.cs
+++ b/src/Editor/NewEditorControl.cs
@@ -599,6 +599,24 @@ namespace Editor
 
         private bool noOnChange = default;
 
+        private void TextBox_Commands_KeyUp(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyData)
+            {
+                case Keys.V | Keys.Control:
+                    (sender as TextBox).Paste();
+                    break;
+
+                case Keys.C | Keys.Control:
+                    (sender as TextBox).Copy();
+                    break;
+
+                case Keys.X | Keys.Control:
+                    (sender as TextBox).Cut();
+                    break;
+            }
+        }
+
         /// <summary>
         /// Обработка нажатий клавиш клавиатуры.
         /// </summary>


### PR DESCRIPTION
Fixes #1608.

```ChangeLog
В окне редактора техобъектов в поиске включены комманды копировать/вставить/вырезать;
```