### PR TITLE
[IOView] Clamps display reserve and text

### DIFF
--- a/src/IO/View/IOViewControl.Designer.cs
+++ b/src/IO/View/IOViewControl.Designer.cs
@@ -105,6 +105,7 @@ namespace IO.View
             this.StructPLC.Collapsed += new System.EventHandler<BrightIdeasSoftware.TreeBranchCollapsedEventArgs>(this.ItemCollapsed);
             this.StructPLC.CellEditFinishing += new BrightIdeasSoftware.CellEditEventHandler(this.CellEditFinishing);
             this.StructPLC.CellEditStarting += new BrightIdeasSoftware.CellEditEventHandler(this.CellEditStarting);
+            this.StructPLC.FormatCell += new System.EventHandler<BrightIdeasSoftware.FormatCellEventArgs>(this.StructPLC_FormatCell);
             this.StructPLC.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.SelectionChanged);
             this.StructPLC.KeyDown += new System.Windows.Forms.KeyEventHandler(this.KeyDownHandler);
             this.StructPLC.MouseEnter += new System.EventHandler(this.StructPLC_MouseEnter);

--- a/src/IO/View/IOViewControl.cs
+++ b/src/IO/View/IOViewControl.cs
@@ -4,6 +4,7 @@ using Editor;
 using Eplan.EplApi.Scripting;
 using IO.ViewModel;
 using PInvoke;
+using StaticHelper;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -350,6 +351,14 @@ namespace IO.View
             e.Handled = true;
             RefreshTree();
             DFrm.GetInstance().RefreshTreeAfterBinding();
+        }
+
+        private void StructPLC_FormatCell(object sender, FormatCellEventArgs e)
+        {
+            if (e.Model is IClamp clamp && !clamp.Binded)
+            {
+                e.Item.SubItems[1].ForeColor = Color.LightSlateGray;
+            }
         }
     }
 }

--- a/src/IO/View/IOViewControl.cs
+++ b/src/IO/View/IOViewControl.cs
@@ -355,7 +355,7 @@ namespace IO.View
 
         private void StructPLC_FormatCell(object sender, FormatCellEventArgs e)
         {
-            if (e.Model is IClamp clamp && !clamp.Binded)
+            if (e.Model is IClamp clamp && !clamp.Bound)
             {
                 e.Item.SubItems[1].ForeColor = Color.LightSlateGray;
             }

--- a/src/IO/ViewModel/Clamp.cs
+++ b/src/IO/ViewModel/Clamp.cs
@@ -17,7 +17,7 @@ namespace IO.ViewModel
 
         public string Description => string.Join(" || ",
             Module.GetClampBinding(clamp)?
-                .Select(g => ChannelBinding(g.Item1, g.Item2)) ?? []);
+                .Select(g => ChannelBinding(g.Item1, g.Item2)) ?? [ Value ]);
 
         /// <summary>
         /// Генерация текста привязки канала устройства к клемме
@@ -56,9 +56,11 @@ namespace IO.ViewModel
 
         Icon IHasIcon.Icon => Icon.Clamp;
 
-        Icon IHasDescriptionIcon.Icon => (Module.Devices[clamp]?.Any() ?? false)? Icon.Cable : Icon.None;
+        Icon IHasDescriptionIcon.Icon => Binded? Icon.Cable : Icon.None;
 
         public string Value => ClampFunction.FunctionalText;
+
+        public bool Binded => Module.Devices[clamp]?.Any() ?? false;
 
         public void Reset()
         {

--- a/src/IO/ViewModel/Clamp.cs
+++ b/src/IO/ViewModel/Clamp.cs
@@ -56,11 +56,11 @@ namespace IO.ViewModel
 
         Icon IHasIcon.Icon => Icon.Clamp;
 
-        Icon IHasDescriptionIcon.Icon => Binded? Icon.Cable : Icon.None;
+        Icon IHasDescriptionIcon.Icon => Bound? Icon.Cable : Icon.None;
 
         public string Value => ClampFunction.FunctionalText;
 
-        public bool Binded => Module.Devices[clamp]?.Any() ?? false;
+        public bool Bound => Module.Devices[clamp]?.Any() ?? false;
 
         public void Reset()
         {

--- a/src/IO/ViewModel/IClamp.cs
+++ b/src/IO/ViewModel/IClamp.cs
@@ -35,6 +35,6 @@ namespace IO.ViewModel
         /// <summary>
         /// К клемме привязано устройство
         /// </summary>
-        bool Binded { get; }
+        bool Bound { get; }
     }
 }

--- a/src/IO/ViewModel/IClamp.cs
+++ b/src/IO/ViewModel/IClamp.cs
@@ -31,5 +31,10 @@ namespace IO.ViewModel
         /// Сброс привязки клеммы в программе (не функционального текста)
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// К клемме привязано устройство
+        /// </summary>
+        bool Binded { get; }
     }
 }


### PR DESCRIPTION
Fixes #1627.

```ChangeLog
Теперь в окне структуры ПЛК отображается функциональный текст с ФСА серым цветом;
```