### PR TITLE
[TechObject] Replace techobjects: no change target and correct modify

### DIFF
--- a/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/BaseObject.Test.cs
+++ b/EasyEplanner.Tests/TechObject.Test/ObjectsTree.Test/BaseObject.Test.cs
@@ -319,8 +319,8 @@ namespace TechObjectTests
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(techObject2.TechType, baseObject.TechObjects[0].TechType);
-                Assert.AreEqual(techObject2.NameEplan, baseObject.TechObjects[0].NameEplan);
+                Assert.AreEqual(techObject1.TechType, baseObject.TechObjects[0].TechType);
+                Assert.AreEqual(techObject1.NameEplan, baseObject.TechObjects[0].NameEplan);
             });
         }
 

--- a/src/Device/DeviceManager.cs
+++ b/src/Device/DeviceManager.cs
@@ -1198,13 +1198,13 @@ namespace EplanDevice
                     // Изменяем номер объекта в устройстве в соответствии с изменениями объекта или для типовых объектов:
                     // ( 1 -> 2 )          :  OBJ[1]V1 -> OBJ[2]V1
                     // ( -1 -> 1, 2,... )  :  OBJ[x]V1 -> OBJ[1]V1, OBJ[2]V1, ... - для типовых объектов 
-                    return GetDeviceByEplanName($"{device.ObjectName}{options.NewTechObjectNumber}{device.DeviceDesignation}");
+                    return GetDeviceByEplanName($"{options.NewTechObjectName}{options.NewTechObjectNumber}{device.DeviceDesignation}");
                 } 
                 else if (device.ObjectNumber == options.NewTechObjectNumber)
                 {
                     // Инверсионное изменение номера объекта: когда устройство имеет номер объекта равный новому номеру объекта
                     // ( 1 -> 2 )  :  OBJ[2]V1 -> OBJ[1]V1
-                    return GetDeviceByEplanName($"{device.ObjectName}{options.OldTechObjectNumber}{device.DeviceDesignation}");
+                    return GetDeviceByEplanName($"{options.NewTechObjectName}{options.OldTechObjectNumber}{device.DeviceDesignation}");
                 }
             }
             else if (options.NameModified && device.ObjectName == options.OldTechObjectName)

--- a/src/EasyEPlanner.csproj
+++ b/src/EasyEPlanner.csproj
@@ -535,6 +535,7 @@
     <Compile Include="TechObject\ObjectsTree\UniversalObject\TechObject.cs" />
     <Compile Include="TechObject\ObjectsTree\UserObject.cs" />
     <Compile Include="TechObject\TechObjectCheckStrategy.cs" />
+    <Compile Include="TechObject\TechObjectIdentifyData.cs" />
     <Compile Include="TechObject\TechObjectManager.cs" />
     <Compile Include="TechObject\TechObjectChecker.cs" />
     <Compile Include="TechObject\TechObjectXMLMaker.cs" />

--- a/src/Editor/ImportExport/TechObjectsExporter.cs
+++ b/src/Editor/ImportExport/TechObjectsExporter.cs
@@ -88,8 +88,7 @@ namespace Editor
                 if (needExporting)
                 {
                     TechObject.TechObject exportingObject = obj.Clone(
-                        techObjectManager.GetTechObjectN, obj.TechNumber,
-                        globalNum, globalNum);
+                        techObjectManager.GetTechObjectN, globalNum, globalNum);
 
                     // Убираем привязку при экспорте.
                     exportingObject.AttachedObjects.SetValue("");

--- a/src/TechObject/ObjectsTree/BaseObject.cs
+++ b/src/TechObject/ObjectsTree/BaseObject.cs
@@ -435,7 +435,7 @@ namespace TechObject
                 int oldObjN = globalObjectsList.IndexOf(techObj) + 1;
                 int newObjN = globalObjectsList.Count + 1;
 
-                var newObject = CloneObject(techObj, newN, oldObjN, newObjN);
+                var newObject = CloneObject(techObj, oldObjN, newObjN, techObj.IdentifyData.WithTechNumber(newN));
 
                 // Работа со списком в дереве и общим списком объектов.
                 techObjects.Add(newObject);
@@ -515,15 +515,12 @@ namespace TechObject
                 copiedObject?.BaseTechObject.Name == baseTechObject.Name;
             if (objectsNotNull && sameBaseObjectName)
             {
-                int newN = techObject.TechNumber;
                 //Старый и новый номер объекта - для замены в ограничениях
-                int oldObjNum = globalObjectsList
-                    .IndexOf(copiedObject) + 1;
-                int newObjNum = globalObjectsList
-                    .IndexOf(techObject) + 1;
+                int oldObjNum = copiedObject.GetLocalNum;
+                int newObjNum = techObject.GetLocalNum;
 
-                var newObject = CloneObject(copyObject, newN, oldObjNum,
-                    newObjNum);
+                var newObject = CloneObject(copyObject, oldObjNum,
+                    newObjNum, techObject.IdentifyData);
 
                 // Список тех. объектов вне групп
                 int toindex = techObjects.IndexOf(techObject);
@@ -561,23 +558,22 @@ namespace TechObject
         /// <param name="oldObjNum">Старый глобальный номер</param>
         /// <param name="newObjNum">Новый глобальный номер</param>
         /// <returns></returns>
-        private TechObject CloneObject(object obj, int newN, int oldObjNum,
-            int newObjNum)
+        private TechObject CloneObject(object obj, int oldObjNum,
+            int newObjNum, ITechObjectIdentifyData techObjectIdentifyData)
         {
             var techObject = obj as TechObject;
-            var stubObject = techObject.Clone(GetTechObjectLocalNum, newN,
-                    oldObjNum, newObjNum);
+            var stubObject = techObject.Clone(GetTechObjectLocalNum,
+                techObjectIdentifyData.TechNumber, oldObjNum, newObjNum);
 
-            bool isInsertCopy = newObjNum > globalObjectsList.Count;
-            if (isInsertCopy)
+            if (newObjNum > globalObjectsList.Count)
             {
-                return CloneForInsert(techObject, stubObject, newN, oldObjNum,
-                    newObjNum);
+                return CloneForInsert(techObject, stubObject, oldObjNum,
+                    newObjNum, techObjectIdentifyData);
             }
             else
             {
-                return CloneForReplace(techObject, stubObject, newN, oldObjNum,
-                    newObjNum);
+                return CloneForReplace(techObject, stubObject, oldObjNum,
+                    newObjNum, techObjectIdentifyData);
             }
         }
 
@@ -591,11 +587,12 @@ namespace TechObject
         /// <param name="newObjNum">Новый глобальный номер</param>
         /// <returns></returns>
         private TechObject CloneForInsert(TechObject cloningObject,
-            TechObject stubObject, int newN, int oldObjNum, int newObjNum)
+            TechObject stubObject, int oldObjNum, int newObjNum,
+            ITechObjectIdentifyData techObjectIdentifyData)
         {
             globalObjectsList.Add(stubObject);
-            var clonedObject = cloningObject.Clone(GetTechObjectLocalNum, newN,
-                oldObjNum, newObjNum);
+            var clonedObject = cloningObject.Clone(GetTechObjectLocalNum,
+                oldObjNum, newObjNum, techObjectIdentifyData);
             globalObjectsList.Remove(stubObject);
             return clonedObject;
         }
@@ -610,12 +607,13 @@ namespace TechObject
         /// <param name="newObjNum">Новый глобальный номер</param>
         /// <returns></returns>
         private TechObject CloneForReplace(TechObject cloningObject,
-            TechObject stubObject, int newN, int oldObjNum, int newObjNum)
+            TechObject stubObject, int oldObjNum, int newObjNum,
+            ITechObjectIdentifyData techObjectIdentifyData)
         {
             var objectFromGlobalList = globalObjectsList[newObjNum - 1];
             globalObjectsList[newObjNum - 1] = stubObject;
-            var clonedObject = cloningObject.Clone(GetTechObjectLocalNum, newN,
-                oldObjNum, newObjNum);
+            var clonedObject = cloningObject.Clone(GetTechObjectLocalNum,
+                oldObjNum, newObjNum, techObjectIdentifyData);
             globalObjectsList[newObjNum - 1] = objectFromGlobalList;
             return clonedObject;
         }

--- a/src/TechObject/ObjectsTree/UniversalObject/TechObject.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/TechObject.cs
@@ -353,15 +353,25 @@ namespace TechObject
             }
         }
 
-        public TechObject Clone(GetN getLocalNum, int newNumber,
-            int oldGlobalNum, int newGlobalNum)
+        public ITechObjectIdentifyData IdentifyData => 
+            new TechObjectIdentifyData(TechNumber, TechType, NameEplan, NameBC);
+
+        public TechObject Clone(GetN getLocalNum, int oldGlobalNum, int newGlobalNum) => 
+            Clone(getLocalNum, oldGlobalNum, newGlobalNum, IdentifyData);
+
+        public TechObject Clone(GetN getLocalNum, int newTechNumber, int oldGlobalNum, int newGlobalNum) =>
+            Clone(getLocalNum, oldGlobalNum, newGlobalNum, IdentifyData.WithTechNumber(newTechNumber));
+
+        public TechObject Clone(GetN getLocalNum, int oldGlobalNum, int newGlobalNum,
+            ITechObjectIdentifyData dataSource)
         {
             TechObject clone = (TechObject)MemberwiseClone();
 
-            clone.techNumber = new TechObjectN(clone, newNumber);
-            clone.techType = new ObjectProperty("Тип", TechType);
-            clone.nameBC = new ObjectProperty("Имя объекта Monitor", NameBC);
-            clone.nameEplan = new NameInEplan(NameEplan, clone);
+            clone.techNumber = new TechObjectN(clone, dataSource.TechNumber);
+            clone.techType = new ObjectProperty("Тип", dataSource.TechType);
+            clone.nameBC = new ObjectProperty("Имя объекта Monitor", dataSource.NameBC);
+            clone.nameEplan = new NameInEplan(dataSource.NameEplan, clone);
+
             clone.attachedObjects = new AttachedObjects(AttachedObjects.Value,
                 clone, AttachedObjects.WorkStrategy);
             clone.cooperParamNumber = cooperParamNumber.Clone();
@@ -378,7 +388,7 @@ namespace TechObject
             clone.systemParams = systemParams.Clone();
 
             clone.modes = modes.Clone(clone);
-            clone.modes.ModifyDevNames(new DevModifyOptions(clone, clone.NameEplan, TechNumber));
+            clone.modes.ModifyDevNames(new DevModifyOptions(clone, NameEplan, TechNumber));
 
             clone.modes.ModifyRestrictObj(oldGlobalNum, newGlobalNum);
 

--- a/src/TechObject/TechObjectIdentifyData.cs
+++ b/src/TechObject/TechObjectIdentifyData.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TechObject;
+
+/// <summary>
+/// Идентификатор тех. обхекта
+/// </summary>
+public interface ITechObjectIdentifyData
+{
+    /// <summary>
+    /// Номер объекта
+    /// </summary>
+    int TechNumber { get; }
+
+    /// <summary>
+    /// Тип объекта
+    /// </summary>
+    int TechType { get; }
+
+    /// <summary>
+    /// ОУ
+    /// </summary>
+    string NameEplan { get; }
+
+    /// <summary>
+    /// Название в Monitor
+    /// </summary>
+    string NameBC { get; }
+
+    /// <summary>
+    /// Установить номер объекта для для идентификатора
+    /// </summary>
+    /// <param name="techNumber"></param>
+    /// <returns></returns>
+    ITechObjectIdentifyData WithTechNumber(int techNumber);
+}
+
+
+public class TechObjectIdentifyData : ITechObjectIdentifyData
+{
+    public TechObjectIdentifyData(int techNumber, int techType, string nameEplan, string nameBC)
+    {
+        TechNumber = techNumber;
+        TechType = techType;
+        NameEplan = nameEplan;
+        NameBC = nameBC;
+    }
+
+
+    public int TechNumber { get; private set; }
+
+    public int TechType { get; private set; }
+
+    public string NameEplan { get; private set; }
+
+    public string NameBC { get; private set; }
+
+    public ITechObjectIdentifyData WithTechNumber(int techNumber)
+    {
+        TechNumber = techNumber;
+        return this;
+    }
+}


### PR DESCRIPTION
Fixes #1780.

```ChangeLog
Теперь при замене объектов не изменяются: Номер, Тип, ОУ, Имя объекта Monitor. Исправлены ошибки модификации названий устройств;
```