### PR TITLE
[TechObject] Equipment: restore save empty value

### DIFF
--- a/src/TechObject/ObjectsTree/UniversalObject/Equipment.cs
+++ b/src/TechObject/ObjectsTree/UniversalObject/Equipment.cs
@@ -103,7 +103,6 @@ namespace TechObject
 
             string equipmentForSave = GetDescendantsParameters()
                 .OfType<EquipmentParameter>()
-                .Where(p => !p.IsEmpty)
                 .Select(p => $"{prefix}\t{p.LuaName} = \'{p.Value}\',\n")
                 .Aggregate("", (r, p) => r + p);
 


### PR DESCRIPTION
Fixes #1794.

```ChangeLog
Исправлено сохранение незаполненного оборудования;
```